### PR TITLE
feat:  Add frontend & backend CI

### DIFF
--- a/backend/.github/workflows/backend-ci.yml
+++ b/backend/.github/workflows/backend-ci.yml
@@ -1,0 +1,30 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [main, develop, feature/*]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  backend:
+    name: Build & Test (.NET 8)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        run: dotnet restore ./FairWorkly.sln
+
+      - name: Build
+        run: dotnet build ./FairWorkly.sln --no-restore -c Release
+
+      - name: Test
+        run: dotnet test ./FairWorkly.sln --no-build -c Release

--- a/frontend/.github/workflows/frontend-ci.yml
+++ b/frontend/.github/workflows/frontend-ci.yml
@@ -1,0 +1,35 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [ main, develop, feature/* ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  frontend:
+    name: Lint, Test & Build (React)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint --if-present
+
+      - name: Test
+        run: npm test --if-present -- --watch=false
+
+      - name: Build
+        run: npm run build
+


### PR DESCRIPTION
**Create a workflow file:**

- Path: `.github/workflows/frontend-ci.yml`
- Triggers:
  - `push` on `main`, `develop`, `feature/*`
  - `pull_request` targeting `main`, `develop`

**Backend job:**

- Use `ubuntu-latest`
- Steps:
  - `actions/checkout@v4`
  - `actions/setup-dotnet@v4` with `.NET 8`
  - `dotnet restore ./backend/FairWorkly.sln`  
  - `dotnet build ./backend/FairWorkly.sln --no-restore -c Release`
  - `dotnet test ./backend/FairWorkly.sln --no-build`

**Frontend job:**

- Use `ubuntu-latest`
- Steps:
  - `actions/checkout@v4`
  - `actions/setup-node@v4` with Node 20
  - `npm ci` in `./frontend` 
  - `npm run lint --if-present`
  - `npm run test --if-present -- --watch=false`
  - `npm run build`