### PR TITLE
sets up the shared API foundation for the FairWorkly frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "^2.10.1",
         "@tanstack/react-query": "^5.90.11",
         "@tanstack/react-query-devtools": "^5.91.0",
+        "axios": "^1.13.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-is": "^18.3.1",
@@ -3561,6 +3562,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
@@ -3766,6 +3784,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -3982,6 +4013,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4091,6 +4134,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -4109,6 +4161,20 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4152,6 +4218,51 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -4616,6 +4727,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4631,6 +4762,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -4684,6 +4831,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4692,6 +4863,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4780,6 +4964,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4802,6 +4998,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -5939,6 +6162,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5968,6 +6200,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -6480,6 +6733,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@reduxjs/toolkit": "^2.10.1",
     "@tanstack/react-query": "^5.90.11",
     "@tanstack/react-query-devtools": "^5.91.0",
+    "axios": "^1.13.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-is": "^18.3.1",

--- a/frontend/src/modules/compliance/hooks/useComplianceQuestion.ts
+++ b/frontend/src/modules/compliance/hooks/useComplianceQuestion.ts
@@ -1,0 +1,14 @@
+import { useApiMutation } from "../../../shared/hooks/useApiMutation";
+import {
+  postComplianceQuestion,
+  type AskComplianceQuestionRequest,
+  type AskComplianceQuestionResponse,
+} from "../../../services/complianceApi";
+
+export function useComplianceQuestion() {
+  return useApiMutation<AskComplianceQuestionResponse, AskComplianceQuestionRequest>(
+    {
+      mutationFn: postComplianceQuestion,
+    },
+  );
+}

--- a/frontend/src/services/baseApi.ts
+++ b/frontend/src/services/baseApi.ts
@@ -1,0 +1,58 @@
+import type { AxiosRequestConfig } from "axios";
+import httpClient from "./httpClient";
+import { normalizeApiError } from "../shared/types/api.types";
+
+/**
+ * 基础 API 工具层
+ * - 统一 try/catch + 错误格式
+ * - 提供强类型 get/post/put/del
+ */
+export async function get<TResponse>(
+  url: string,
+  config?: AxiosRequestConfig,
+): Promise<TResponse> {
+  try {
+    const res = await httpClient.get<TResponse>(url, config);
+    return res.data;
+  } catch (err) {
+    throw normalizeApiError(err);
+  }
+}
+
+export async function post<TResponse, TBody = unknown>(
+  url: string,
+  body?: TBody,
+  config?: AxiosRequestConfig,
+): Promise<TResponse> {
+  try {
+    const res = await httpClient.post<TResponse>(url, body, config);
+    return res.data;
+  } catch (err) {
+    throw normalizeApiError(err);
+  }
+}
+
+export async function put<TResponse, TBody = unknown>(
+  url: string,
+  body?: TBody,
+  config?: AxiosRequestConfig,
+): Promise<TResponse> {
+  try {
+    const res = await httpClient.put<TResponse>(url, body, config);
+    return res.data;
+  } catch (err) {
+    throw normalizeApiError(err);
+  }
+}
+
+export async function del<TResponse>(
+  url: string,
+  config?: AxiosRequestConfig,
+): Promise<TResponse> {
+  try {
+    const res = await httpClient.delete<TResponse>(url, config);
+    return res.data;
+  } catch (err) {
+    throw normalizeApiError(err);
+  }
+}

--- a/frontend/src/services/complianceApi.ts
+++ b/frontend/src/services/complianceApi.ts
@@ -1,0 +1,37 @@
+import { post } from "./baseApi";
+
+/**
+ * 占位，证明链路可用
+ * 后续 Compliance Q&A ticket 会在这里补真实 DTO
+ */
+export interface AskComplianceQuestionRequest {
+  question: string;
+  awardCode?: string;
+  audience: "admin"|"manager" | "employee";
+  orgId?: string;
+  userId?: string;
+}
+
+export interface AskComplianceQuestionResponse {
+  plainExplanation: string;
+  keyPoints: string[];
+  riskLevel: "green" | "yellow" | "red";
+  whatToDoNext: string[];
+  legalReferences: Array<{
+    source: "NES" | "Award" | "FairWork" | "Other";
+    title: string;
+    url?: string | null;
+  }>;
+  disclaimer: string;
+}
+
+export function postComplianceQuestion(
+  payload: AskComplianceQuestionRequest,
+): Promise<AskComplianceQuestionResponse> {
+  // 注意：baseURL 已在 httpClient 统一设置为 /api
+  // 所以这里写 /compliance/qa
+  return post<AskComplianceQuestionResponse, AskComplianceQuestionRequest>(
+    "/compliance/qa",
+    payload,
+  );
+}

--- a/frontend/src/services/documentsApi.ts
+++ b/frontend/src/services/documentsApi.ts
@@ -1,0 +1,23 @@
+import { post } from "./baseApi";
+
+/**
+ * Documents 模块 API 骨架
+ * 后续会补：
+ * - generate offer/contract/warning letter
+ * - template upload & diff
+ */
+
+export interface DocumentsPlaceholderRequest {
+  ping: true;
+}
+
+export interface DocumentsPlaceholderResponse {
+  ok: boolean;
+}
+
+export function documentsHealthCheck(): Promise<DocumentsPlaceholderResponse> {
+  return post<DocumentsPlaceholderResponse, DocumentsPlaceholderRequest>(
+    "/documents/health",
+    { ping: true },
+  );
+}

--- a/frontend/src/services/employeeApi.ts
+++ b/frontend/src/services/employeeApi.ts
@@ -1,0 +1,24 @@
+import { post } from "./baseApi";
+
+/**
+ * Employee 模块 API 骨架
+ * 后续会补：
+ * - leave balance query
+ * - employment type lookup
+ * - policy summary
+ */
+
+export interface EmployeePlaceholderRequest {
+  ping: true;
+}
+
+export interface EmployeePlaceholderResponse {
+  ok: boolean;
+}
+
+export function employeeHealthCheck(): Promise<EmployeePlaceholderResponse> {
+  return post<EmployeePlaceholderResponse, EmployeePlaceholderRequest>(
+    "/employee/health",
+    { ping: true },
+  );
+}

--- a/frontend/src/services/httpClient.ts
+++ b/frontend/src/services/httpClient.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+
+/**
+ * 统一 HTTP 客户端
+ * - 所有模块 API 都从这里发请求
+ *
+ * baseURL 优先读取环境变量
+ * - Vite: import.meta.env.VITE_API_BASE_URL
+ * - 默认 /api
+ */
+const baseURL = import.meta.env.VITE_API_BASE_URL ?? "/api";
+const httpClient = axios.create({
+  baseURL,
+  timeout: 15000,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// ------- Request Interceptor (Auth Placeholder) -------
+httpClient.interceptors.request.use((config) => {
+  // 简单占位
+  // 后续做 auth 模块时再换成更正式的 token 管理
+  const token = localStorage.getItem("authToken");
+
+  if (token) {
+    config.headers = config.headers ?? {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  return config;
+});
+
+// ------- Response Interceptor (Optional lightweight handling) -------
+httpClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    // 这里不做“强行格式化”，交给 baseApi 统一 normalize
+    return Promise.reject(error);
+  },
+);
+
+export default httpClient;

--- a/frontend/src/services/payrollApi.ts
+++ b/frontend/src/services/payrollApi.ts
@@ -1,0 +1,24 @@
+import { post } from "./baseApi";
+
+/**
+ * Payroll 模块 API 骨架
+ * 后续会补：
+ * - pay run CSV import check
+ * - SG check
+ * - STP field validation
+ */
+
+export interface PayrollPlaceholderRequest {
+  ping: true;
+}
+
+export interface PayrollPlaceholderResponse {
+  ok: boolean;
+}
+
+export function payrollHealthCheck(): Promise<PayrollPlaceholderResponse> {
+  return post<PayrollPlaceholderResponse, PayrollPlaceholderRequest>(
+    "/payroll/health",
+    { ping: true },
+  );
+}

--- a/frontend/src/shared/hooks/useApiMutation.ts
+++ b/frontend/src/shared/hooks/useApiMutation.ts
@@ -1,0 +1,18 @@
+import {
+  useMutation,
+  type UseMutationOptions,
+} from "@tanstack/react-query";
+import type { ApiError } from "../types/api.types";
+
+/**
+ * 统一 Mutation 包装
+ * - 这里先不做强制 toast
+ * - 后面接 notificationsSlice 再加
+ */
+export function useApiMutation<TData, TVariables = void>(
+  options: UseMutationOptions<TData, ApiError, TVariables>,
+) {
+  return useMutation<TData, ApiError, TVariables>({
+    ...options,
+  });
+}

--- a/frontend/src/shared/hooks/useApiQuery.ts
+++ b/frontend/src/shared/hooks/useApiQuery.ts
@@ -1,0 +1,30 @@
+import {
+  useQuery,
+  type UseQueryOptions,
+  type QueryKey,
+} from "@tanstack/react-query";
+import type { ApiError } from "../types/api.types";
+
+/**
+ * 统一 Query 包装
+ * - 默认只对“可能是临时问题”的错误轻度重试
+ */
+function defaultRetryCount(failureCount: number, error: ApiError) {
+  const status = error.status;
+
+  // 4xx 一般不重试
+  if (status && status >= 400 && status < 500) return false;
+
+  // 网络/5xx 允许小幅重试
+  return failureCount < 1;
+}
+
+export function useApiQuery<TData, TQueryKey extends QueryKey = QueryKey>(
+  options: UseQueryOptions<TData, ApiError, TData, TQueryKey>,
+) {
+  return useQuery<TData, ApiError, TData, TQueryKey>({
+    staleTime: 30_000,
+    ...options,
+    retry: (failureCount, error) => defaultRetryCount(failureCount, error),
+  });
+}

--- a/frontend/src/shared/types/api.types.ts
+++ b/frontend/src/shared/types/api.types.ts
@@ -1,0 +1,68 @@
+import type { AxiosError } from "axios";
+
+/**
+ * 全项目统一的 API 错误模型
+ * - 让 UI / hooks 不需要理解 axios 的内部结构
+ */
+export interface ApiError {
+  status?: number;
+  message: string;
+  code?: string;
+  details?: unknown;
+  raw?: unknown; // 保留原始错误，方便调试
+}
+
+/**
+ * 约定后端可能返回的错误结构（可按后端实际格式调整）
+ */
+export interface BackendErrorShape {
+  message?: string;
+  code?: string;
+  details?: unknown;
+}
+
+/**
+ * 类型守卫：判断是否 axios error
+ */
+export function isAxiosError(error: unknown): error is AxiosError {
+  return typeof error === "object" && error !== null && "isAxiosError" in error;
+}
+
+/**
+ * 把未知错误统一转换成 ApiError
+ */
+export function normalizeApiError(error: unknown): ApiError {
+  // Axios 错误
+  if (isAxiosError(error)) {
+    const status = error.response?.status;
+    const data = error.response?.data as BackendErrorShape | undefined;
+
+    // 优先用后端 message，其次用 axios message
+    const message =
+      data?.message ||
+      error.message ||
+      "Request failed. Please try again.";
+
+    return {
+      status,
+      message,
+      code: data?.code,
+      details: data?.details,
+      raw: error,
+    };
+  }
+
+  // 原生 Error
+  if (error instanceof Error) {
+    return {
+      message: error.message || "Unexpected error.",
+      raw: error,
+    };
+  }
+
+  // 兜底
+  return {
+    message: "Network error. Please try again.",
+    raw: error,
+  };
+}


### PR DESCRIPTION
issue #73 
## Summary

This PR sets up the shared API foundation for the FairWorkly frontend so feature teams can build module hooks consistently and quickly.

It introduces:
- A single HTTP client (`httpClient.ts`)
- A typed base API wrapper with centralized error normalization (`baseApi.ts`)
- A shared `ApiError` model
- Lightweight TanStack Query wrappers (`useApiQuery`, `useApiMutation`)
- Initial module API stubs for Compliance/Payroll/Documents/Employee


---

## Changes

### 1. HTTP client

- Added `src/services/httpClient.ts`
  - Axios instance with:
    - `baseURL` using Vite env `VITE_API_BASE_URL` fallback to `/api`
    - Default JSON headers
    - Timeout
  - Request interceptor attaches a placeholder auth token (`localStorage`)

### 2. Base API wrapper

- Added `src/services/baseApi.ts`
  - Typed helpers:
    - `get<TResponse>()`
    - `post<TResponse, TBody>()`
    - `put<TResponse, TBody>()`
    - `del<TResponse>()`
  - Centralized try/catch
  - Throws normalized `ApiError`

### 3. Shared API types

- Added `src/shared/types/api.types.ts`
  - `ApiError` interface
  - `normalizeApiError()` helper
  - Optional backend error shape support

### 4. Shared React Query wrappers

- Added:
  - `src/shared/hooks/useApiQuery.ts`
  - `src/shared/hooks/useApiMutation.ts`
- Standardized:
  - error typing (`ApiError`)
  - minimal retry behavior for queries

### 5. Module API entry points

- Added stubs:
  - `src/services/complianceApi.ts`
  - `src/services/payrollApi.ts`
  - `src/services/documentsApi.ts`
  - `src/services/employeeApi.ts`
- `complianceApi` includes a minimal `postComplianceQuestion` placeholder to demonstrate the pattern.

### 6. Vite env typing

- Added `src/env.d.ts`
  - Ensures TypeScript recognizes `import.meta.env.VITE_API_BASE_URL`.

### 7. Dependencies

- Added:
  - `axios`
  - `@tanstack/react-query`
- Updated `package.json` and `package-lock.json`.

---

## How to test

1. From `frontend/`:

   ```bash
   npm install
   npm run dev
