### PR TITLE
Initialise Redux store and global UI state

### DIFF
--- a/frontend/src/app/providers/ReduxProvider.tsx
+++ b/frontend/src/app/providers/ReduxProvider.tsx
@@ -1,41 +1,11 @@
-// src/app/providers/ReduxProvider.tsx
-import React from "react";
-import { Provider } from "react-redux";
-import { configureStore, createSlice } from "@reduxjs/toolkit";
-
-interface UiState {
-  sidebarOpen: boolean;
-}
-
-const initialUiState: UiState = {
-  sidebarOpen: true,
-};
-
-// Temporary uiSlice，can move to src/slices/uiSlice.ts in the future
-const uiSlice = createSlice({
-  name: "ui",
-  initialState: initialUiState,
-  reducers: {
-    toggleSidebar(state) {
-      state.sidebarOpen = !state.sidebarOpen;
-    },
-  },
-});
-
-// can move to src/store/index.ts in the future and use "import { store } from "../../store";" instead
-const tempStore = configureStore({ 
-  reducer: {
-    ui: uiSlice.reducer,
-  },
-});
-
-export type RootState = ReturnType<typeof tempStore.getState>;
-export type AppDispatch = typeof tempStore.dispatch;
+import React from 'react'
+import { Provider } from 'react-redux'
+import { store } from '../../store'
 
 interface ReduxProviderProps {
-  children: React.ReactNode;
+  children: React.ReactNode
 }
 
 export const ReduxProvider: React.FC<ReduxProviderProps> = ({ children }) => {
-  return <Provider store={tempStore}>{children}</Provider>;
-};
+  return <Provider store={store}>{children}</Provider>
+}

--- a/frontend/src/slices/auth/authSlice.ts
+++ b/frontend/src/slices/auth/authSlice.ts
@@ -1,0 +1,50 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+export interface AuthUser {
+  id?: string;
+  name?: string;
+  role?: string; // e.g. "owner" | "manager" | "employee"
+}
+
+export interface AuthState {
+  isAuthenticated: boolean;
+  user?: AuthUser;
+  token?: string; // placeholder; you can remove if you don't store token in Redux
+}
+
+const initialState: AuthState = {
+  isAuthenticated: false,
+  user: undefined,
+  token: undefined,
+};
+
+const authSlice = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {
+    setAuthenticated(state, action: PayloadAction<boolean>) {
+      state.isAuthenticated = action.payload;
+      if (!action.payload) {
+        state.user = undefined;
+        state.token = undefined;
+      }
+    },
+    setUser(state, action: PayloadAction<AuthUser | undefined>) {
+      state.user = action.payload;
+    },
+    setToken(state, action: PayloadAction<string | undefined>) {
+      state.token = action.payload;
+    },
+    logout(state) {
+      state.isAuthenticated = false;
+      state.user = undefined;
+      state.token = undefined;
+    },
+  },
+});
+
+export const { setAuthenticated, setUser, setToken, logout } =
+  authSlice.actions;
+
+export default authSlice.reducer;

--- a/frontend/src/slices/auth/index.ts
+++ b/frontend/src/slices/auth/index.ts
@@ -1,0 +1,2 @@
+export { default as authReducer } from "./authSlice";
+export * from "./authSlice";

--- a/frontend/src/slices/notifications/index.ts
+++ b/frontend/src/slices/notifications/index.ts
@@ -1,0 +1,2 @@
+export { default as notificationsReducer } from "./notificationsSlice";
+export * from "./notificationsSlice";

--- a/frontend/src/slices/notifications/notificationsSlice.ts
+++ b/frontend/src/slices/notifications/notificationsSlice.ts
@@ -1,0 +1,53 @@
+import { createSlice, nanoid } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+export type NotificationVariant = "success" | "info" | "warning" | "error";
+
+export interface NotificationItem {
+  id: string;
+  message: string;
+  variant: NotificationVariant;
+  durationMs?: number;
+}
+
+export interface NotificationsState {
+  queue: NotificationItem[];
+}
+
+const initialState: NotificationsState = {
+  queue: [],
+};
+
+const notificationsSlice = createSlice({
+  name: "notifications",
+  initialState,
+  reducers: {
+    enqueueNotification: {
+      reducer(state, action: PayloadAction<NotificationItem>) {
+        state.queue.push(action.payload);
+      },
+      prepare(input: Omit<NotificationItem, "id">) {
+        return {
+          payload: {
+            id: nanoid(),
+            ...input,
+          },
+        };
+      },
+    },
+    dequeueNotification(state) {
+      state.queue.shift();
+    },
+    clearNotifications(state) {
+      state.queue = [];
+    },
+  },
+});
+
+export const {
+  enqueueNotification,
+  dequeueNotification,
+  clearNotifications,
+} = notificationsSlice.actions;
+
+export default notificationsSlice.reducer;

--- a/frontend/src/slices/ui/index.ts
+++ b/frontend/src/slices/ui/index.ts
@@ -1,0 +1,2 @@
+export { default as uiReducer } from "./uiSlice";
+export * from "./uiSlice";

--- a/frontend/src/slices/ui/uiSlice.ts
+++ b/frontend/src/slices/ui/uiSlice.ts
@@ -1,0 +1,44 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+export type ThemeMode = "light" | "dark";
+
+export interface UiState {
+  sidebarOpen: boolean;
+  globalLoading: boolean;
+  themeMode: ThemeMode; // placeholder for future theme toggle
+}
+
+const initialState: UiState = {
+  sidebarOpen: true,
+  globalLoading: false,
+  themeMode: "light",
+};
+
+const uiSlice = createSlice({
+  name: "ui",
+  initialState,
+  reducers: {
+    toggleSidebar(state) {
+      state.sidebarOpen = !state.sidebarOpen;
+    },
+    setSidebarOpen(state, action: PayloadAction<boolean>) {
+      state.sidebarOpen = action.payload;
+    },
+    setGlobalLoading(state, action: PayloadAction<boolean>) {
+      state.globalLoading = action.payload;
+    },
+    setThemeMode(state, action: PayloadAction<ThemeMode>) {
+      state.themeMode = action.payload;
+    },
+  },
+});
+
+export const {
+  toggleSidebar,
+  setSidebarOpen,
+  setGlobalLoading,
+  setThemeMode,
+} = uiSlice.actions;
+
+export default uiSlice.reducer;

--- a/frontend/src/store/hooks.ts
+++ b/frontend/src/store/hooks.ts
@@ -1,0 +1,6 @@
+import { useDispatch, useSelector } from "react-redux";
+import type { TypedUseSelectorHook } from "react-redux";
+import type { RootState, AppDispatch } from "./index";
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,0 +1,11 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { rootReducer } from "./rootReducer";
+
+export const store = configureStore({
+  reducer: rootReducer,
+  // middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
+  // devTools: true,
+});
+
+export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;

--- a/frontend/src/store/rootReducer.ts
+++ b/frontend/src/store/rootReducer.ts
@@ -1,0 +1,13 @@
+import { combineReducers } from "@reduxjs/toolkit";
+
+import { authReducer } from "../slices/auth";
+import { uiReducer } from "../slices/ui";
+import { notificationsReducer } from "../slices/notifications";
+
+export const rootReducer = combineReducers({
+  auth: authReducer,
+  ui: uiReducer,
+  notifications: notificationsReducer,
+});
+
+export type RootState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
## Summary

This PR introduces the official Redux setup for the FairWorkly frontend, replacing the temporary inline Redux configuration.  
It adds:

- A typed Redux store (`src/store/`)
- Root reducer with domain slices (auth, ui, notifications)
- Typed hooks (`useAppDispatch`, `useAppSelector`)
- Barrel file exports for each slice directory
- `verbatimModuleSyntax`-compatible type-only imports

This establishes a clean and scalable global state foundation used across all modules.

---

## Changes

### 1. Added official Redux store

**New files:**

- `src/store/index.ts` — configures the store
- `src/store/rootReducer.ts` — combines all reducers
- `src/store/hooks.ts` — typed selector/dispatch hooks

Store now registers three slices:

- `auth`
- `ui`
- `notifications`

---

### 2. Moved slices into domain folders

**New structure:**
src/slices/
auth/
authSlice.ts
index.ts
ui/
uiSlice.ts
index.ts
notifications/
notificationsSlice.ts
index.ts

Each `index.ts` now exports:

```ts
export { default as authReducer } from "./authSlice";
export * from "./authSlice";

### 3. Updated ReduxProvider to use the real store

**Notes**

- This PR only adds global state;business data continues to use React Query.

- This prepares the foundation for:

- Auth flow
- Sidebar layout state
- Global loading & notifications
- Future multi-module UI controls