### PR TITLE
To align with Postgres's snake_case convention, packaging and configuration

### DIFF
--- a/backend/src/FairWorkly.Infrastructure/DependencyInjection.cs
+++ b/backend/src/FairWorkly.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,4 @@
-﻿using FairWorkly.Application.Common.Interfaces;
+using FairWorkly.Application.Common.Interfaces;
 using FairWorkly.Infrastructure.AI.Mocks;
 using FairWorkly.Infrastructure.AI.PythonServices;
 using FairWorkly.Infrastructure.Persistence;
@@ -30,8 +30,10 @@ public static class DependencyInjection
 
         // Register DbContext (PostgreSQL)
         var connectionString = configuration.GetConnectionString("DefaultConnection");
-
-        services.AddDbContext<FairWorklyDbContext>(options => options.UseNpgsql(connectionString));
+        // UseSnakeCaseNamingConvention for PostgreSQL
+        services.AddDbContext<FairWorklyDbContext>(options =>
+            options.UseNpgsql(connectionString).UseSnakeCaseNamingConvention()
+        );
 
         // Register Repositories
 

--- a/backend/src/FairWorkly.Infrastructure/FairWorkly.Infrastructure.csproj
+++ b/backend/src/FairWorkly.Infrastructure/FairWorkly.Infrastructure.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.22" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />


### PR DESCRIPTION
**Issue:** #96 

**Description:** 
Infrastructure layer Installs EFCore.NamingConventions - 8.0.3

Configure in Infrastructure/DependencyIndjection.cs
```
services.AddDbContext<FairWorklyDbContext>(options =>
    options.UseNpgsql(connectionString).UseSnakeCaseNamingConvention()
);
```