### PR TITLE
Remove empty root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "FairWorkly",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary
- Remove empty `package-lock.json` from project root, accidentally introduced via merge commit in #136
- The real `package-lock.json` lives in `frontend/`