### PR TITLE
fix: resolve refresh token test race condition

### DIFF
--- a/backend/tests/FairWorkly.IntegrationTests/Auth/RefreshTests.cs
+++ b/backend/tests/FairWorkly.IntegrationTests/Auth/RefreshTests.cs
@@ -133,8 +133,8 @@ public class RefreshTests : AuthTestsBase
     [Fact]
     public async Task Refresh_ValidToken_Returns200WithNewAccessToken()
     {
-        // Arrange - Get a valid refresh token by logging in first
-        var refreshToken = await GetRefreshTokenFromCookieAsync();
+        // Arrange - Set up a valid refresh token directly in DB
+        var refreshToken = await SetupValidRefreshTokenAsync();
         var client = CreateClientWithRefreshCookie(refreshToken);
 
         // Act


### PR DESCRIPTION
## Summary
- `Refresh_ExpiredToken` and `Refresh_ValidToken` tests were flaky due to parallel xUnit test classes (`LoginTests`, `MeTests`) rotating the shared `test@example.com` user's refresh token mid-test
- Replaced login-based token setup with direct DB hash insertion, matching the pattern already used by `Refresh_DisabledAccount_Returns403`
- All 29 backend tests now pass reliably

## Test plan
- [x] `dotnet test` — 29/29 passed (including all 5 RefreshTests)
- [ ] Verify CI passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved token refresh authentication test setup by using direct database initialization instead of login workflow dependencies, enhancing test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->