### PR TITLE
Centralize Result<T>-to-ActionResult mapping with IActionFilter

### DIFF
--- a/backend/src/FairWorkly.API/Filters/ResultMappingFilter.cs
+++ b/backend/src/FairWorkly.API/Filters/ResultMappingFilter.cs
@@ -1,0 +1,82 @@
+using FairWorkly.Domain.Common;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace FairWorkly.API.Filters;
+
+/// <summary>
+/// Globally intercepts ObjectResult responses containing Result&lt;T&gt; values
+/// and transforms them into appropriate HTTP responses with ProblemDetails for errors.
+///
+/// Controllers signal the filter by returning: new ObjectResult(result)
+/// where result implements IResultBase.
+///
+/// For success cases, the filter unwraps Result&lt;T&gt;.Value and returns 200 OK.
+/// For failure cases, the filter maps ResultType to the appropriate HTTP status code
+/// with a ProblemDetails body consistent with GlobalExceptionHandler.
+/// </summary>
+public class ResultMappingFilter : IAsyncActionFilter
+{
+    public async Task OnActionExecutionAsync(
+        ActionExecutingContext context,
+        ActionExecutionDelegate next)
+    {
+        var executedContext = await next();
+
+        if (executedContext.Result is not ObjectResult objectResult)
+            return;
+
+        if (objectResult.Value is not IResultBase result)
+            return;
+
+        if (result.IsSuccess)
+        {
+            var value = objectResult.Value
+                .GetType()
+                .GetProperty(nameof(Result<object>.Value))
+                ?.GetValue(objectResult.Value);
+
+            executedContext.Result = new OkObjectResult(value);
+            return;
+        }
+
+        executedContext.Result = MapFailureToActionResult(result, context.HttpContext);
+    }
+
+    private static ObjectResult MapFailureToActionResult(
+        IResultBase result,
+        HttpContext httpContext)
+    {
+        var (statusCode, title) = result.Type switch
+        {
+            ResultType.ValidationFailure => (StatusCodes.Status400BadRequest, "Validation Failed"),
+            ResultType.BusinessFailure => (StatusCodes.Status400BadRequest, "Bad Request"),
+            ResultType.NotFound => (StatusCodes.Status404NotFound, "Resource Not Found"),
+            ResultType.Unauthorized => (StatusCodes.Status401Unauthorized, "Unauthorized"),
+            ResultType.Forbidden => (StatusCodes.Status403Forbidden, "Forbidden"),
+            _ => (StatusCodes.Status400BadRequest, "Bad Request"),
+        };
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = result.Type == ResultType.ValidationFailure
+                ? "One or more validation errors occurred."
+                : result.ErrorMessage,
+            Instance = httpContext.Request.Path,
+        };
+
+        if (result.Type == ResultType.ValidationFailure
+            && result.ValidationErrors is { Count: > 0 })
+        {
+            var errors = result.ValidationErrors
+                .GroupBy(e => e.Field)
+                .ToDictionary(g => g.Key, g => g.Select(e => e.Message).ToArray());
+
+            problemDetails.Extensions.Add("errors", errors);
+        }
+
+        return new ObjectResult(problemDetails) { StatusCode = statusCode };
+    }
+}

--- a/backend/src/FairWorkly.API/Program.cs
+++ b/backend/src/FairWorkly.API/Program.cs
@@ -47,8 +47,11 @@ try
     builder.Services.AddApplicationServices();
     builder.Services.AddInfrastructureServices(builder.Configuration);
 
-    // Add controllers
-    builder.Services.AddControllers();
+    // Add controllers with global Result<T> → ActionResult mapping filter
+    builder.Services.AddControllers(options =>
+    {
+        options.Filters.Add<FairWorkly.API.Filters.ResultMappingFilter>();
+    });
 
     // Add Swagger generator
     builder.Services.AddEndpointsApiExplorer();

--- a/backend/tests/FairWorkly.UnitTests/FairWorkly.UnitTests.csproj
+++ b/backend/tests/FairWorkly.UnitTests/FairWorkly.UnitTests.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\FairWorkly.API\FairWorkly.API.csproj" />
     <ProjectReference Include="..\..\src\FairWorkly.Domain\FairWorkly.Domain.csproj" />
     <ProjectReference Include="..\..\src\FairWorkly.Application\FairWorkly.Application.csproj" />
     <ProjectReference Include="..\..\src\FairWorkly.Infrastructure\FairWorkly.Infrastructure.csproj" />

--- a/backend/tests/FairWorkly.UnitTests/Unit/ResultMappingFilterTests.cs
+++ b/backend/tests/FairWorkly.UnitTests/Unit/ResultMappingFilterTests.cs
@@ -1,0 +1,194 @@
+using FairWorkly.API.Filters;
+using FairWorkly.Domain.Common;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+
+namespace FairWorkly.UnitTests.Unit;
+
+public class ResultMappingFilterTests
+{
+    private readonly ResultMappingFilter _filter = new();
+
+    // ── Success mapping ──
+
+    [Fact]
+    public async Task OnActionExecution_SuccessResult_ReturnsOkObjectResultWithUnwrappedValue()
+    {
+        var dto = new TestDto { Name = "test" };
+        var result = Result<TestDto>.Success(dto);
+        var (ctx, next) = CreateFilterContexts(new ObjectResult(result));
+
+        await _filter.OnActionExecutionAsync(ctx, next);
+
+        var executed = await next();
+        executed.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = (OkObjectResult)executed.Result!;
+        okResult.Value.Should().Be(dto);
+        okResult.StatusCode.Should().Be(200);
+    }
+
+    // ── Failure mapping ──
+
+    [Fact]
+    public async Task OnActionExecution_ValidationFailure_Returns400WithProblemDetailsAndErrors()
+    {
+        var errors = new List<ValidationError>
+        {
+            new() { Field = "Email", Message = "Email is required" },
+            new() { Field = "Email", Message = "Email must be valid" },
+            new() { Field = "Password", Message = "Password is required" },
+        };
+        var result = Result<TestDto>.ValidationFailure(errors);
+        var (ctx, next) = CreateFilterContexts(new ObjectResult(result));
+
+        await _filter.OnActionExecutionAsync(ctx, next);
+
+        var executed = await next();
+        executed.Result.Should().BeOfType<ObjectResult>();
+        var objResult = (ObjectResult)executed.Result!;
+        objResult.StatusCode.Should().Be(400);
+
+        var pd = objResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        pd.Title.Should().Be("Validation Failed");
+        pd.Detail.Should().Be("One or more validation errors occurred.");
+        pd.Instance.Should().Be("/api/test");
+        pd.Extensions.Should().ContainKey("errors");
+
+        var groupedErrors = pd.Extensions["errors"] as Dictionary<string, string[]>;
+        groupedErrors.Should().NotBeNull();
+        groupedErrors!["Email"].Should().HaveCount(2);
+        groupedErrors["Password"].Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task OnActionExecution_BusinessFailure_Returns400WithProblemDetails()
+    {
+        var result = Result<TestDto>.Failure("Something went wrong");
+        var (ctx, next) = CreateFilterContexts(new ObjectResult(result));
+
+        await _filter.OnActionExecutionAsync(ctx, next);
+
+        var executed = await next();
+        AssertProblemDetails(executed.Result!, 400, "Bad Request", "Something went wrong");
+    }
+
+    [Fact]
+    public async Task OnActionExecution_NotFound_Returns404WithProblemDetails()
+    {
+        var result = Result<TestDto>.NotFound("Resource not found");
+        var (ctx, next) = CreateFilterContexts(new ObjectResult(result));
+
+        await _filter.OnActionExecutionAsync(ctx, next);
+
+        var executed = await next();
+        AssertProblemDetails(executed.Result!, 404, "Resource Not Found", "Resource not found");
+    }
+
+    [Fact]
+    public async Task OnActionExecution_Unauthorized_Returns401WithProblemDetails()
+    {
+        var result = Result<TestDto>.Unauthorized("Invalid credentials");
+        var (ctx, next) = CreateFilterContexts(new ObjectResult(result));
+
+        await _filter.OnActionExecutionAsync(ctx, next);
+
+        var executed = await next();
+        AssertProblemDetails(executed.Result!, 401, "Unauthorized", "Invalid credentials");
+    }
+
+    [Fact]
+    public async Task OnActionExecution_Forbidden_Returns403WithProblemDetails()
+    {
+        var result = Result<TestDto>.Forbidden("Access denied");
+        var (ctx, next) = CreateFilterContexts(new ObjectResult(result));
+
+        await _filter.OnActionExecutionAsync(ctx, next);
+
+        var executed = await next();
+        AssertProblemDetails(executed.Result!, 403, "Forbidden", "Access denied");
+    }
+
+    // ── Passthrough ──
+
+    [Fact]
+    public async Task OnActionExecution_NonResultObjectResult_PassesThrough()
+    {
+        var original = new ObjectResult(new { foo = "bar" });
+        var (ctx, next) = CreateFilterContexts(original);
+
+        await _filter.OnActionExecutionAsync(ctx, next);
+
+        var executed = await next();
+        executed.Result.Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public async Task OnActionExecution_FileResult_PassesThrough()
+    {
+        var original = new FileContentResult(new byte[] { 1, 2, 3 }, "application/octet-stream");
+        var (ctx, next) = CreateFilterContexts(original);
+
+        await _filter.OnActionExecutionAsync(ctx, next);
+
+        var executed = await next();
+        executed.Result.Should().BeSameAs(original);
+    }
+
+    // ── Helpers ──
+
+    private static (ActionExecutingContext ctx, ActionExecutionDelegate next) CreateFilterContexts(
+        IActionResult actionResult,
+        string requestPath = "/api/test")
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Path = requestPath;
+
+        var actionContext = new ActionContext(
+            httpContext,
+            new RouteData(),
+            new ActionDescriptor());
+
+        var executingContext = new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            controller: null!);
+
+        var executedContext = new ActionExecutedContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            controller: null!)
+        {
+            Result = actionResult,
+        };
+
+        ActionExecutionDelegate next = () => Task.FromResult(executedContext);
+
+        return (executingContext, next);
+    }
+
+    private static void AssertProblemDetails(
+        IActionResult actionResult,
+        int expectedStatus,
+        string expectedTitle,
+        string expectedDetail)
+    {
+        actionResult.Should().BeOfType<ObjectResult>();
+        var objResult = (ObjectResult)actionResult;
+        objResult.StatusCode.Should().Be(expectedStatus);
+
+        var pd = objResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        pd.Title.Should().Be(expectedTitle);
+        pd.Detail.Should().Be(expectedDetail);
+        pd.Instance.Should().Be("/api/test");
+    }
+
+    private class TestDto
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary

- Create `ResultMappingFilter` (`IAsyncActionFilter`) that automatically maps `Result<T>` to HTTP responses with ProblemDetails (RFC 7807), eliminating duplicated error-handling logic in controllers
- Remove `HandleValidationFailureAsync` duplication from `AuthController` and `RosterController`
- Simplify all 7 controller actions that use `Result<T>` — controllers now return `new ObjectResult(result)` and the filter handles the rest
- Update frontend `normalizeApiError` to support ProblemDetails `detail` field alongside legacy `message` format
- Add 8 unit tests for the filter and update error-handling architecture documentation

## How it works

Controllers wrap the mediator result in `new ObjectResult(result)`. The globally-registered filter detects `IResultBase` and maps:

| ResultType | HTTP | ProblemDetails Title |
|---|---|---|
| Success | 200 | _(unwraps value)_ |
| ValidationFailure | 400 | Validation Failed + field errors |
| BusinessFailure | 400 | Bad Request |
| NotFound | 404 | Resource Not Found |
| Unauthorized | 401 | Unauthorized |
| Forbidden | 403 | Forbidden |

For actions with side effects (Login/Refresh cookie-setting), controllers handle success manually and delegate errors to the filter via `if (result.IsFailure) return new ObjectResult(result)`.

## Breaking changes

Non-validation error responses change from `{ message: "..." }` to ProblemDetails format `{ status, title, detail, instance }`. Frontend `normalizeApiError` updated to read `detail` first with `message` fallback — backward compatible.

## Test plan

- [x] 8 new unit tests: success mapping, all 5 failure types, non-Result passthrough, FileResult passthrough
- [x] All 163 unit tests pass (`dotnet test`)
- [x] Frontend TypeScript compiles (`tsc --noEmit`)
- [ ] Smoke test Login, Refresh, Upload, GetDetails via Swagger

Closes #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API error responses now follow RFC 7807 ProblemDetails standard for enhanced consistency and clarity.
  * Improved validation error reporting with detailed, structured error information.
  * More consistent error handling with proper HTTP status codes across all authentication and data endpoints.
  * Better error responses for validation failures, authorization, authentication, and not-found scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->