### PR TITLE
Restrict payroll validation endpoint to Admin role only

### DIFF
--- a/backend/src/FairWorkly.API/Controllers/Payroll/PayrollController.cs
+++ b/backend/src/FairWorkly.API/Controllers/Payroll/PayrollController.cs
@@ -16,7 +16,7 @@ public class PayrollController : BaseApiController
     }
 
     [HttpPost("validation")]
-    [Authorize(Policy = "RequireManager")]
+    [Authorize(Policy = "RequireAdmin")]
     [RequestSizeLimit(2_097_152)] // 2MB
     public async Task<IActionResult> Validate(
         IFormFile file,


### PR DESCRIPTION
## Summary

- Changed `[Authorize(Policy = "RequireManager")]` to `[Authorize(Policy = "RequireAdmin")]` on `PayrollController.Validate`
- Frontend route guard and sidebar were already admin-only — this aligns the backend

## Verification

- Integration test added: Manager role → 403 Forbidden
- All 8 payroll integration tests pass
- Manual test: Manager gets 403, Admin gets 200

Closes #271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Access Control Updates**
  * Payroll validation endpoint now requires Admin permissions instead of Manager permissions for access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->