### PR TITLE
refactor(agent): lazy-load langchain-huggingface for slim Docker image

### DIFF
--- a/agent-service/shared/llm/embeddings_factory.py
+++ b/agent-service/shared/llm/embeddings_factory.py
@@ -6,7 +6,6 @@ import logging
 from typing import Optional, Dict, Any
 
 from langchain_core.embeddings import Embeddings
-from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_openai import OpenAIEmbeddings
 
 
@@ -23,6 +22,13 @@ def create_embeddings(
         model_name = model_params.get("local_embedding_model")
         if not model_name:
             raise ValueError("local_embedding_model must be set for local embeddings")
+        try:
+            from langchain_huggingface import HuggingFaceEmbeddings
+        except ImportError:
+            raise ImportError(
+                "langchain-huggingface is required for local embeddings. "
+                "Install it with: poetry install --with local-models"
+            )
         logger.debug("Creating local embeddings using %s", model_name)
         return HuggingFaceEmbeddings(model_name=model_name)
 

--- a/agent-service/shared/llm/embeddings_factory.py
+++ b/agent-service/shared/llm/embeddings_factory.py
@@ -24,11 +24,11 @@ def create_embeddings(
             raise ValueError("local_embedding_model must be set for local embeddings")
         try:
             from langchain_huggingface import HuggingFaceEmbeddings
-        except ImportError:
+        except ImportError as err:
             raise ImportError(
                 "langchain-huggingface is required for local embeddings. "
                 "Install it with: poetry install --with local-models"
-            )
+            ) from err
         logger.debug("Creating local embeddings using %s", model_name)
         return HuggingFaceEmbeddings(model_name=model_name)
 


### PR DESCRIPTION
## Summary
- Moved `langchain-huggingface` import from top-level to inside the `local` embedding mode branch
- Prevents `ImportError` when running with `--only main` (online mode), supporting the slim Docker image (~666MB vs 12.7GB)
- No functional change — `deployment_mode_embedding: online` uses OpenAI API and never touches HuggingFace

## Test plan
- [ ] Verify agent-service starts without `langchain-huggingface` installed (online mode)
- [ ] Verify compliance Q&A works with OpenAI embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Embedding initialization now uses lazy loading for local providers, improving startup stability by deferring dependency checks until needed. Missing local dependencies now produce clearer, actionable installation messages at runtime. Online embedding behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->