### PR TITLE
feat(fairbot): add multi-agent compliance debate

### DIFF
--- a/agent-service/agents/debate/feature.py
+++ b/agent-service/agents/debate/feature.py
@@ -1,0 +1,174 @@
+"""DebateFeature — multi-agent compliance debate orchestrator.
+
+Three agents evaluate a shift scenario in sequence:
+  1. Roster Agent  — surface-level pay-rate assessment
+  2. Payroll Agent — challenges/confirms with Award detail + cumulative hours (RAG)
+  3. Fair Bot      — final arbitration with Award citation (RAG)
+"""
+
+import asyncio
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from master_agent.config import load_config
+from master_agent.feature_registry import FeatureBase
+from shared.llm.factory import LLMProviderFactory
+from shared.rag.retriever_manager import ensure_retriever
+
+from .models import DebateResult, DebateRound, ShiftScenario
+
+_PROMPTS_DIR = Path(__file__).parent / "prompts"
+_LLM_TIMEOUT = 30
+
+logger = logging.getLogger(__name__)
+
+
+def _load_prompt(name: str) -> str:
+    return (_PROMPTS_DIR / f"{name}.txt").read_text(encoding="utf-8")
+
+
+def _scenario_text(s: ShiftScenario) -> str:
+    lines = [
+        f"Employee: {s.employee_name}",
+        f"Shift date: {s.shift_date}",
+        f"Shift hours: {s.shift_hours}",
+        f"Hours already worked this week (before this shift): {s.week_hours_before_shift}",
+        f"Applicable Award: {s.award_name}",
+    ]
+    if s.extra_context:
+        lines.append(f"Additional context: {s.extra_context}")
+    return "\n".join(lines)
+
+
+def _parse_field(text: str, field: str) -> str:
+    """Extract a labelled field value from structured LLM output."""
+    pattern = rf"^{field}:\s*(.+?)(?=\n[A-Z_]+:|$)"
+    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+    return match.group(1).strip() if match else ""
+
+
+class DebateFeature(FeatureBase):
+    """Orchestrates a three-round multi-agent compliance debate."""
+
+    async def process(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        scenario = ShiftScenario(**payload["scenario"])
+        config = load_config()
+        start = time.perf_counter()
+
+        scenario_str = _scenario_text(scenario)
+
+        # --- Retrieve Award excerpts once (shared by Payroll Agent + Fair Bot) ---
+        award_excerpts = ""
+        rag_sources: List[Dict[str, Any]] = []
+        try:
+            retriever, _ = ensure_retriever(config, logger)
+            query = f"{scenario.award_name} overtime penalty rates Saturday {scenario.extra_context or ''}"
+            top_k = config.get("faiss", {}).get("similarity_search_k_docs", 3)
+            retrieval = await retriever.retrieve(query, top_k=top_k)
+            award_excerpts = retriever.format_context_for_llm(retrieval)
+            rag_sources = retrieval.metadatas
+        except Exception:
+            logger.warning("RAG retrieval failed for debate; proceeding without Award excerpts", exc_info=True)
+
+        llm = LLMProviderFactory.create()
+        model_name: Optional[str] = None
+        rounds: List[DebateRound] = []
+
+        # ── Round 1: Roster Agent ────────────────────────────────────
+        roster_prompt = _load_prompt("roster_agent")
+        roster_messages = [
+            {"role": "system", "content": roster_prompt},
+            {"role": "user", "content": f"Shift Scenario:\n{scenario_str}"},
+        ]
+        roster_raw = await self._call_llm(llm, roster_messages)
+        model_name = roster_raw.get("model")
+        roster_text = roster_raw.get("content", "")
+
+        rounds.append(DebateRound(
+            agent="Roster Agent",
+            role="Shift Analyst",
+            icon="📋",
+            stance=_parse_field(roster_text, "STANCE"),
+            reasoning=_parse_field(roster_text, "REASONING"),
+        ))
+
+        # ── Round 2: Payroll Agent ───────────────────────────────────
+        payroll_prompt = _load_prompt("payroll_agent").format(
+            scenario=scenario_str,
+            roster_opinion=roster_text,
+            award_name=scenario.award_name,
+            award_excerpts=award_excerpts or "(No Award excerpts available)",
+        )
+        payroll_messages = [
+            {"role": "system", "content": payroll_prompt},
+            {"role": "user", "content": "Please review the Roster Agent's assessment and provide your analysis."},
+        ]
+        payroll_raw = await self._call_llm(llm, payroll_messages)
+        payroll_text = payroll_raw.get("content", "")
+
+        rounds.append(DebateRound(
+            agent="Payroll Agent",
+            role="Payroll Compliance Specialist",
+            icon="💰",
+            stance=_parse_field(payroll_text, "STANCE"),
+            reasoning=_parse_field(payroll_text, "REASONING"),
+            challenges=_parse_field(payroll_text, "CHALLENGES"),
+            sources=rag_sources,
+        ))
+
+        # ── Round 3: Fair Bot ────────────────────────────────────────
+        fairbot_prompt = _load_prompt("fairbot_agent").format(
+            scenario=scenario_str,
+            roster_opinion=roster_text,
+            payroll_opinion=payroll_text,
+            award_name=scenario.award_name,
+            award_excerpts=award_excerpts or "(No Award excerpts available)",
+        )
+        fairbot_messages = [
+            {"role": "system", "content": fairbot_prompt},
+            {"role": "user", "content": "Please deliver your final ruling on this compliance question."},
+        ]
+        fairbot_raw = await self._call_llm(llm, fairbot_messages)
+        fairbot_text = fairbot_raw.get("content", "")
+
+        rounds.append(DebateRound(
+            agent="Fair Bot",
+            role="Compliance Arbitrator",
+            icon="⚖️",
+            stance=_parse_field(fairbot_text, "RULING"),
+            reasoning=_parse_field(fairbot_text, "REASONING"),
+            challenges=_parse_field(fairbot_text, "AGREES_WITH"),
+            sources=rag_sources,
+        ))
+
+        cited_section = _parse_field(fairbot_text, "CITED_SECTION")
+
+        elapsed = time.perf_counter() - start
+        logger.info("Debate completed in %.2fs (%d rounds)", elapsed, len(rounds))
+
+        result = DebateResult(
+            scenario_summary=scenario_str,
+            rounds=rounds,
+            final_ruling=_parse_field(fairbot_text, "RULING"),
+            cited_award_section=cited_section or None,
+            model=model_name,
+        )
+        return result.model_dump()
+
+    async def _call_llm(
+        self, llm, messages: List[Dict[str, str]]
+    ) -> Dict[str, Any]:
+        try:
+            return await asyncio.wait_for(
+                llm.generate(messages, temperature=0.4, max_tokens=600),
+                timeout=_LLM_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.error("LLM call timed out after %ds", _LLM_TIMEOUT)
+            return {"content": "(Agent timed out)", "model": None}
+        except Exception:
+            logger.exception("LLM call failed in debate")
+            return {"content": "(Agent unavailable)", "model": None}

--- a/agent-service/agents/debate/feature.py
+++ b/agent-service/agents/debate/feature.py
@@ -13,6 +13,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from pydantic import ValidationError
+
 from master_agent.config import load_config
 from master_agent.feature_registry import FeatureBase
 from shared.llm.factory import LLMProviderFactory
@@ -88,11 +90,24 @@ def _build_insufficient_evidence_result(
     )
 
 
+def _parse_scenario_payload(payload: Dict[str, Any]) -> ShiftScenario:
+    scenario_payload = payload.get("scenario")
+    if scenario_payload is None:
+        raise ValueError("Debate payload must include a 'scenario' object.")
+    if not isinstance(scenario_payload, dict):
+        raise ValueError("Debate payload 'scenario' must be an object.")
+
+    try:
+        return ShiftScenario(**scenario_payload)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid debate scenario payload: {exc}") from exc
+
+
 class DebateFeature(FeatureBase):
     """Orchestrates a three-round multi-agent compliance debate."""
 
     async def process(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        scenario = ShiftScenario(**payload["scenario"])
+        scenario = _parse_scenario_payload(payload)
         config = load_config()
         start = time.perf_counter()
 

--- a/agent-service/agents/debate/feature.py
+++ b/agent-service/agents/debate/feature.py
@@ -24,6 +24,7 @@ _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _LLM_TIMEOUT = 30
 
 logger = logging.getLogger(__name__)
+_NO_RELEVANT_DOCS = "No relevant documents found."
 
 
 def _load_prompt(name: str) -> str:
@@ -50,6 +51,43 @@ def _parse_field(text: str, field: str) -> str:
     return match.group(1).strip() if match else ""
 
 
+def _has_award_evidence(award_excerpts: str) -> bool:
+    normalized = award_excerpts.strip()
+    return bool(normalized) and normalized != _NO_RELEVANT_DOCS
+
+
+def _build_insufficient_evidence_result(
+    scenario: ShiftScenario,
+    scenario_str: str,
+    rag_sources: List[Dict[str, Any]],
+) -> DebateResult:
+    reasoning = (
+        f"FairWorkly could not retrieve usable excerpts from {scenario.award_name} that directly "
+        "support the required rate tiers or overtime thresholds for this scenario. The debate was "
+        "stopped to avoid unsupported payroll guidance. Retrieve the relevant Award clauses and rerun "
+        "the analysis."
+    )
+    return DebateResult(
+        scenario_summary=scenario_str,
+        rounds=[
+            DebateRound(
+                agent="Fair Bot",
+                role="Compliance Arbitrator",
+                icon="⚖️",
+                stance="Insufficient retrieved Award evidence to determine the exact pay rate.",
+                reasoning=reasoning,
+                sources=rag_sources,
+            )
+        ],
+        final_ruling=(
+            "Insufficient retrieved Award evidence to determine the exact pay rate. "
+            "Retrieve the relevant Award clauses and rerun this debate."
+        ),
+        cited_award_section=None,
+        model=None,
+    )
+
+
 class DebateFeature(FeatureBase):
     """Orchestrates a three-round multi-agent compliance debate."""
 
@@ -65,23 +103,47 @@ class DebateFeature(FeatureBase):
         rag_sources: List[Dict[str, Any]] = []
         try:
             retriever, _ = ensure_retriever(config, logger)
-            query = f"{scenario.award_name} overtime penalty rates Saturday {scenario.extra_context or ''}"
+            query_parts = [
+                scenario.award_name,
+                scenario.shift_date,
+                f"{scenario.shift_hours} hour shift",
+                f"{scenario.week_hours_before_shift} hours already worked this week",
+                "penalty rates overtime thresholds",
+            ]
+            if scenario.extra_context:
+                query_parts.append(scenario.extra_context)
+            query = " ".join(str(part) for part in query_parts if part)
             top_k = config.get("faiss", {}).get("similarity_search_k_docs", 3)
             retrieval = await retriever.retrieve(query, top_k=top_k)
             award_excerpts = retriever.format_context_for_llm(retrieval)
             rag_sources = retrieval.metadatas
         except Exception:
-            logger.warning("RAG retrieval failed for debate; proceeding without Award excerpts", exc_info=True)
+            logger.warning(
+                "RAG retrieval failed for debate; returning insufficient-evidence fallback",
+                exc_info=True,
+            )
+
+        if not _has_award_evidence(award_excerpts):
+            logger.info("Debate skipped due to missing usable Award excerpts")
+            return _build_insufficient_evidence_result(
+                scenario=scenario,
+                scenario_str=scenario_str,
+                rag_sources=rag_sources,
+            ).model_dump()
 
         llm = LLMProviderFactory.create()
         model_name: Optional[str] = None
         rounds: List[DebateRound] = []
 
         # ── Round 1: Roster Agent ────────────────────────────────────
-        roster_prompt = _load_prompt("roster_agent")
+        roster_prompt = _load_prompt("roster_agent").format(
+            scenario=scenario_str,
+            award_name=scenario.award_name,
+            award_excerpts=award_excerpts,
+        )
         roster_messages = [
             {"role": "system", "content": roster_prompt},
-            {"role": "user", "content": f"Shift Scenario:\n{scenario_str}"},
+            {"role": "user", "content": "Review the retrieved Award excerpts and provide your initial assessment."},
         ]
         roster_raw = await self._call_llm(llm, roster_messages)
         model_name = roster_raw.get("model")
@@ -93,6 +155,7 @@ class DebateFeature(FeatureBase):
             icon="📋",
             stance=_parse_field(roster_text, "STANCE"),
             reasoning=_parse_field(roster_text, "REASONING"),
+            sources=rag_sources,
         ))
 
         # ── Round 2: Payroll Agent ───────────────────────────────────

--- a/agent-service/agents/debate/models.py
+++ b/agent-service/agents/debate/models.py
@@ -1,0 +1,63 @@
+"""Pydantic models for the multi-agent debate feature."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ShiftScenario(BaseModel):
+    """Input scenario describing a shift to be evaluated."""
+
+    employee_name: str = Field(..., description="Employee name, e.g. 'Alice'")
+    shift_date: str = Field(..., description="Date of the shift, e.g. '2024-03-16 (Saturday)'")
+    shift_hours: float = Field(..., description="Total hours worked on this shift")
+    week_hours_before_shift: float = Field(
+        0,
+        description="Hours already worked earlier in the week (Mon-Fri) before this shift",
+    )
+    award_name: str = Field(
+        "Hospitality Industry (General) Award 2020",
+        description="Applicable Modern Award name",
+    )
+    extra_context: Optional[str] = Field(
+        None,
+        description="Any additional context (e.g. public holiday, casual employee, etc.)",
+    )
+
+
+class DebateRequest(BaseModel):
+    """API request body for the debate endpoint."""
+
+    scenario: ShiftScenario
+
+
+class DebateRound(BaseModel):
+    """One round of the multi-agent debate."""
+
+    agent: str = Field(..., description="Agent name: Roster Agent / Payroll Agent / Fair Bot")
+    role: str = Field(..., description="Agent role label")
+    icon: str = Field(..., description="Display icon for this agent")
+    stance: str = Field(..., description="One-line position summary")
+    reasoning: str = Field(..., description="Full reasoning text from the agent")
+    challenges: Optional[str] = Field(
+        None,
+        description="What this agent disagrees with from previous rounds",
+    )
+    sources: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Award sources cited (from RAG retrieval)",
+    )
+
+
+class DebateResult(BaseModel):
+    """Complete debate output returned to the client."""
+
+    scenario_summary: str = Field(..., description="Plain-language restatement of the scenario")
+    rounds: list[DebateRound]
+    final_ruling: str = Field(..., description="The arbitrated outcome")
+    cited_award_section: Optional[str] = Field(
+        None, description="Key Award section cited in the ruling"
+    )
+    model: Optional[str] = Field(None, description="LLM model used")

--- a/agent-service/agents/debate/prompts/fairbot_agent.txt
+++ b/agent-service/agents/debate/prompts/fairbot_agent.txt
@@ -13,7 +13,9 @@ Your job is to:
 2. Determine which agent's analysis is more accurate (or synthesise a correct answer from both).
 3. Deliver a clear, authoritative FINAL RULING with the specific Award section that supports it.
 
-Be decisive. The employer needs to know exactly what rate to pay and why.
+Use ONLY the supplied Award excerpts as authority. If they do not support an exact rate or clause-based ruling, your final ruling must say the evidence is insufficient and must not invent a rate from general knowledge.
+
+Be decisive. The employer needs to know exactly what rate to pay and why, or that the current evidence is insufficient to answer safely.
 
 ## Context
 
@@ -31,11 +33,11 @@ Be decisive. The employer needs to know exactly what rate to pay and why.
 
 ## Response Format (strict)
 
-RULING: <one definitive sentence — the correct pay treatment>
+RULING: <one definitive sentence — the correct pay treatment, or that the supplied Award evidence is insufficient>
 
 AGREES_WITH: <"Roster Agent" or "Payroll Agent" or "Neither — corrected below">
 
 REASONING:
-<3-5 sentences. Reference the specific Award clause(s) that resolve the disagreement. Explain why the losing agent's interpretation was incorrect. Use precise language.>
+<3-5 sentences. Reference the specific Award clause(s) that resolve the disagreement. Explain why the losing agent's interpretation was incorrect. If the excerpts are insufficient, explicitly say so and identify the missing clause or rate detail. Use precise language.>
 
-CITED_SECTION: <The specific Award section number and title, e.g. "Section 33.2 — Overtime for full-time employees">
+CITED_SECTION: <The specific Award section number and title, e.g. "Section 33.2 — Overtime for full-time employees", or "None — insufficient retrieved Award evidence">

--- a/agent-service/agents/debate/prompts/fairbot_agent.txt
+++ b/agent-service/agents/debate/prompts/fairbot_agent.txt
@@ -1,0 +1,41 @@
+You are **Fair Bot**, the final arbitrator in FairWorkly's multi-agent compliance review panel.
+
+Your expertise: Australian workplace law, Modern Award interpretation, and dispute resolution. You have the authority to make the final ruling. You have access to the relevant Award excerpts below.
+
+## Your Task
+
+Two agents have provided their assessments of a pay-rate scenario:
+- **Roster Agent**: gave an initial surface-level assessment.
+- **Payroll Agent**: reviewed and either challenged or confirmed the Roster Agent's stance.
+
+Your job is to:
+1. Evaluate both positions against the Award text.
+2. Determine which agent's analysis is more accurate (or synthesise a correct answer from both).
+3. Deliver a clear, authoritative FINAL RULING with the specific Award section that supports it.
+
+Be decisive. The employer needs to know exactly what rate to pay and why.
+
+## Context
+
+### Shift Scenario
+{scenario}
+
+### Roster Agent's Assessment
+{roster_opinion}
+
+### Payroll Agent's Assessment
+{payroll_opinion}
+
+### Relevant Award Excerpts (retrieved from {award_name})
+{award_excerpts}
+
+## Response Format (strict)
+
+RULING: <one definitive sentence — the correct pay treatment>
+
+AGREES_WITH: <"Roster Agent" or "Payroll Agent" or "Neither — corrected below">
+
+REASONING:
+<3-5 sentences. Reference the specific Award clause(s) that resolve the disagreement. Explain why the losing agent's interpretation was incorrect. Use precise language.>
+
+CITED_SECTION: <The specific Award section number and title, e.g. "Section 33.2 — Overtime for full-time employees">

--- a/agent-service/agents/debate/prompts/payroll_agent.txt
+++ b/agent-service/agents/debate/prompts/payroll_agent.txt
@@ -1,0 +1,33 @@
+You are the **Payroll Agent** in FairWorkly's multi-agent compliance review panel.
+
+Your expertise: payroll calculations, cumulative weekly hours tracking, Award overtime thresholds, and penalty rate interactions. You have access to the relevant Modern Award excerpts below.
+
+## Your Task
+
+The Roster Agent has already provided an initial pay-rate assessment. Your job is to:
+1. Review the Roster Agent's stance and reasoning.
+2. Cross-check against cumulative weekly hours, Award overtime triggers, and any rate-stacking rules.
+3. If you DISAGREE, clearly state what the Roster Agent got wrong and provide the correct calculation.
+4. If you AGREE, confirm and add any nuance.
+
+You should be assertive and precise. Use specific dollar amounts or multipliers where possible.
+
+## Context
+
+### Shift Scenario
+{scenario}
+
+### Roster Agent's Assessment
+{roster_opinion}
+
+### Relevant Award Excerpts (retrieved from {award_name})
+{award_excerpts}
+
+## Response Format (strict)
+
+STANCE: <one sentence — your corrected or confirmed rate determination>
+
+CHALLENGES: <one sentence about what the Roster Agent missed or got right, starting with "I disagree because..." or "I agree, and additionally...">
+
+REASONING:
+<3-5 sentences with your detailed analysis. Reference specific Award sections/clauses where possible. Show calculations (e.g. "38 ordinary hours already worked → all Saturday hours are overtime at 200%"). Cite the Award excerpt that supports your position.>

--- a/agent-service/agents/debate/prompts/payroll_agent.txt
+++ b/agent-service/agents/debate/prompts/payroll_agent.txt
@@ -10,7 +10,9 @@ The Roster Agent has already provided an initial pay-rate assessment. Your job i
 3. If you DISAGREE, clearly state what the Roster Agent got wrong and provide the correct calculation.
 4. If you AGREE, confirm and add any nuance.
 
-You should be assertive and precise. Use specific dollar amounts or multipliers where possible.
+You must ground every rate, multiplier, threshold, and clause reference in the supplied Award excerpts only. If the excerpts do not support an exact answer, say the evidence is insufficient and do not fill gaps from general payroll knowledge or model memory.
+
+You should be assertive and precise. Use specific dollar amounts or multipliers only when the supplied Award excerpts support them.
 
 ## Context
 
@@ -30,4 +32,4 @@ STANCE: <one sentence — your corrected or confirmed rate determination>
 CHALLENGES: <one sentence about what the Roster Agent missed or got right, starting with "I disagree because..." or "I agree, and additionally...">
 
 REASONING:
-<3-5 sentences with your detailed analysis. Reference specific Award sections/clauses where possible. Show calculations (e.g. "38 ordinary hours already worked → all Saturday hours are overtime at 200%"). Cite the Award excerpt that supports your position.>
+<3-5 sentences with your detailed analysis. Reference specific Award sections/clauses where possible. Show calculations only when the supplied excerpts support them. If the excerpts are insufficient, explicitly say so and explain what clause or rate detail is missing.>

--- a/agent-service/agents/debate/prompts/roster_agent.txt
+++ b/agent-service/agents/debate/prompts/roster_agent.txt
@@ -1,18 +1,28 @@
 You are the **Roster Agent** in FairWorkly's multi-agent compliance review panel.
 
-Your expertise: reading rosters, identifying shift types (weekday, Saturday, Sunday, public holiday), and applying the most straightforward pay-rate interpretation based on the shift itself.
+Your expertise: reading rosters, identifying shift types (weekday, Saturday, Sunday, public holiday), and applying the most straightforward pay-rate interpretation based on the shift itself. You have access to the retrieved Award excerpts below.
 
 ## Your Task
 
 Given a shift scenario, provide your INITIAL assessment of the correct pay rate. At this stage you should ONLY consider the shift in isolation — the day of the week, the hours worked, and the basic penalty/overtime structure in the applicable Award.
 
-Do NOT consider cumulative weekly hours or complex Award interactions — that is the Payroll Agent's job. Keep your analysis simple and surface-level on purpose, so the Payroll Agent has something concrete to review and potentially correct.
+Use ONLY the supplied Award excerpts as support for your answer. If the excerpts do not clearly support an exact rate, tier split, or clause-based conclusion, say the evidence is insufficient and do not infer percentages or thresholds from general knowledge.
+
+Do NOT consider cumulative weekly hours or complex Award interactions unless the supplied excerpts explicitly require it — that is the Payroll Agent's job. Keep your analysis simple and surface-level on purpose, so the Payroll Agent has something concrete to review and potentially correct.
+
+## Context
+
+### Shift Scenario
+{scenario}
+
+### Relevant Award Excerpts (retrieved from {award_name})
+{award_excerpts}
 
 ## Response Format (strict)
 
 Respond with EXACTLY this structure — no extra keys, no markdown fences:
 
-STANCE: <one sentence summarising your rate determination>
+STANCE: <one sentence summarising your rate determination, or that the supplied Award evidence is insufficient>
 
 REASONING:
-<2-4 sentences explaining your logic. Mention the day, hours, and which rate tiers you applied. Use specific numbers where possible (e.g. "first 8 hours at 150%, remaining 2 hours at 200%").>
+<2-4 sentences explaining your logic. Mention the day, hours, and which rate tiers you applied only if the supplied excerpts explicitly support them. Cite the relevant clause or excerpt wording where possible, and state that the evidence is insufficient if it does not support an exact answer.>

--- a/agent-service/agents/debate/prompts/roster_agent.txt
+++ b/agent-service/agents/debate/prompts/roster_agent.txt
@@ -1,0 +1,18 @@
+You are the **Roster Agent** in FairWorkly's multi-agent compliance review panel.
+
+Your expertise: reading rosters, identifying shift types (weekday, Saturday, Sunday, public holiday), and applying the most straightforward pay-rate interpretation based on the shift itself.
+
+## Your Task
+
+Given a shift scenario, provide your INITIAL assessment of the correct pay rate. At this stage you should ONLY consider the shift in isolation — the day of the week, the hours worked, and the basic penalty/overtime structure in the applicable Award.
+
+Do NOT consider cumulative weekly hours or complex Award interactions — that is the Payroll Agent's job. Keep your analysis simple and surface-level on purpose, so the Payroll Agent has something concrete to review and potentially correct.
+
+## Response Format (strict)
+
+Respond with EXACTLY this structure — no extra keys, no markdown fences:
+
+STANCE: <one sentence summarising your rate determination>
+
+REASONING:
+<2-4 sentences explaining your logic. Mention the day, hours, and which rate tiers you applied. Use specific numbers where possible (e.g. "first 8 hours at 150%, remaining 2 hours at 200%").>

--- a/agent-service/master_agent/intent_router.py
+++ b/agent-service/master_agent/intent_router.py
@@ -8,6 +8,7 @@ class IntentRouter:
         "payroll_explain": "payroll_verify",
         "compliance": "compliance_qa",
         "compliance_qa": "compliance_qa",
+        "debate": "debate",
     }
 
     def route(self, message: str, file_name: str = None, intent_hint: str = None) -> str:

--- a/agent-service/master_agent/main.py
+++ b/agent-service/master_agent/main.py
@@ -26,6 +26,8 @@ from master_agent.feature_registry import FeatureRegistry
 
 # Import features from domain packages
 from agents.compliance.feature import ComplianceFeature
+from agents.debate.feature import DebateFeature
+from agents.debate.models import DebateRequest
 from agents.payroll.feature import PayrollFeature
 from agents.payroll.models import PayrollExplainRequest
 from agents.roster.feature import RosterFeature
@@ -162,8 +164,10 @@ registry = FeatureRegistry()
 registry.register("compliance_qa", ComplianceFeature())
 registry.register("roster", RosterFeature())
 registry.register("roster_explain", RosterExplainFeature())
+registry.register("debate", DebateFeature())
 
 payroll_feature = PayrollFeature()
+debate_feature = registry.get_feature("debate")
 
 logger = logging.getLogger(__name__)
 
@@ -278,6 +282,23 @@ async def chat(
         "routed_to": feature_type,
         "result": result,
     }
+
+
+@app.post("/api/agent/debate")
+async def debate(
+    request: DebateRequest,
+    _: None = Depends(verify_service_key),
+):
+    """Multi-agent compliance debate — three agents evaluate a shift scenario."""
+    try:
+        result = await debate_feature.process(request.model_dump())
+        return JSONResponse(content={"code": 200, "msg": "OK", "data": result})
+    except Exception:
+        logger.exception("Unhandled error in debate endpoint")
+        return JSONResponse(
+            content={"code": 500, "msg": "Internal processing error"},
+            status_code=500,
+        )
 
 
 @app.post("/api/agent/payroll/explain")

--- a/agent-service/tests/test_debate_feature.py
+++ b/agent-service/tests/test_debate_feature.py
@@ -1,0 +1,139 @@
+import asyncio
+from types import SimpleNamespace
+
+from agents.debate import feature as debate_feature_module
+from agents.debate.feature import DebateFeature
+from shared.llm.factory import LLMProviderFactory
+
+
+def _scenario_payload() -> dict:
+    return {
+        "scenario": {
+            "employee_name": "Alice",
+            "shift_date": "2024-03-16 (Saturday)",
+            "shift_hours": 10,
+            "week_hours_before_shift": 38,
+            "award_name": "Hospitality Industry (General) Award 2020",
+            "extra_context": "Full-time employee",
+        }
+    }
+
+
+def test_debate_returns_insufficient_evidence_when_award_retrieval_is_empty(monkeypatch):
+    class _EmptyRetriever:
+        async def retrieve(self, query: str, top_k: int = 3):
+            return SimpleNamespace(documents=[], metadatas=[])
+
+        def format_context_for_llm(self, retrieval) -> str:
+            return "No relevant documents found."
+
+    def _unexpected_llm_create():
+        raise AssertionError("LLM should not be created when Award evidence is missing")
+
+    monkeypatch.setattr(
+        debate_feature_module,
+        "ensure_retriever",
+        lambda *_args, **_kwargs: (_EmptyRetriever(), None),
+    )
+    monkeypatch.setattr(LLMProviderFactory, "create", _unexpected_llm_create)
+
+    result = asyncio.run(DebateFeature().process(_scenario_payload()))
+
+    assert result["final_ruling"].startswith(
+        "Insufficient retrieved Award evidence to determine the exact pay rate."
+    )
+    assert result["cited_award_section"] is None
+    assert result["rounds"] == [
+        {
+            "agent": "Fair Bot",
+            "role": "Compliance Arbitrator",
+            "icon": "⚖️",
+            "stance": "Insufficient retrieved Award evidence to determine the exact pay rate.",
+            "reasoning": (
+                "FairWorkly could not retrieve usable excerpts from Hospitality Industry "
+                "(General) Award 2020 that directly support the required rate tiers or "
+                "overtime thresholds for this scenario. The debate was stopped to avoid "
+                "unsupported payroll guidance. Retrieve the relevant Award clauses and "
+                "rerun the analysis."
+            ),
+            "challenges": None,
+            "sources": [],
+        }
+    ]
+
+
+def test_debate_passes_retrieved_award_excerpts_to_roster_agent(monkeypatch):
+    excerpt = (
+        "Based on these Fair Work documents:\n\n"
+        "[1] hospitality-award.pdf (page 12): Clause 29.3 says Saturday work is paid at 150%.\n\n"
+    )
+    captured_messages = []
+    captured_query = {}
+
+    class _Retriever:
+        async def retrieve(self, query: str, top_k: int = 3):
+            captured_query["value"] = query
+            return SimpleNamespace(
+                documents=["Clause 29.3 says Saturday work is paid at 150%."],
+                metadatas=[{"source": "hospitality-award.pdf", "page": 12}],
+            )
+
+        def format_context_for_llm(self, retrieval) -> str:
+            return excerpt
+
+    class _StubLLM:
+        async def generate(self, messages, temperature: float = 0.4, max_tokens: int = 600):
+            captured_messages.append(messages)
+            system_prompt = messages[0]["content"]
+            if "Roster Agent" in system_prompt:
+                return {
+                    "content": (
+                        "STANCE: Saturday hours are paid at 150% based on the retrieved excerpt.\n\n"
+                        "REASONING:\n"
+                        "The supplied Award excerpt states that Saturday work is paid at 150%. "
+                        "I am limiting this initial view to the shift in isolation and not "
+                        "adding any weekly overtime assumptions."
+                    ),
+                    "model": "stub-model",
+                }
+            if "Payroll Agent" in system_prompt:
+                return {
+                    "content": (
+                        "STANCE: The retrieved excerpts support Saturday work at 150%, but weekly "
+                        "overtime would need explicit Award support.\n\n"
+                        "CHALLENGES: I agree, and additionally the rate must stay grounded in the "
+                        "retrieved Award text.\n\n"
+                        "REASONING:\n"
+                        "The supplied excerpt supports the Saturday multiplier. I would need a "
+                        "retrieved overtime clause before asserting any higher rate."
+                    ),
+                    "model": "stub-model",
+                }
+            return {
+                "content": (
+                    "RULING: The retrieved Award excerpt supports Saturday work at 150%, and no "
+                    "higher rate is justified without an overtime clause.\n\n"
+                    "AGREES_WITH: Payroll Agent\n\n"
+                    "REASONING:\n"
+                    "The payroll view is the safest because it stays within the retrieved Award "
+                    "text. There is no retrieved overtime clause supporting a higher multiplier.\n\n"
+                    "CITED_SECTION: Clause 29.3 - Saturday work"
+                ),
+                "model": "stub-model",
+            }
+
+    monkeypatch.setattr(
+        debate_feature_module,
+        "ensure_retriever",
+        lambda *_args, **_kwargs: (_Retriever(), None),
+    )
+    monkeypatch.setattr(LLMProviderFactory, "create", lambda: _StubLLM())
+
+    result = asyncio.run(DebateFeature().process(_scenario_payload()))
+
+    roster_system_prompt = captured_messages[0][0]["content"]
+    assert excerpt in roster_system_prompt
+    assert "Use ONLY the supplied Award excerpts as support for your answer." in roster_system_prompt
+    assert "2024-03-16 (Saturday)" in captured_query["value"]
+    assert result["rounds"][0]["sources"] == [{"source": "hospitality-award.pdf", "page": 12}]
+    assert result["model"] == "stub-model"

--- a/agent-service/tests/test_debate_feature.py
+++ b/agent-service/tests/test_debate_feature.py
@@ -19,6 +19,15 @@ def _scenario_payload() -> dict:
     }
 
 
+def test_debate_requires_scenario_payload():
+    try:
+        asyncio.run(DebateFeature().process({}))
+    except ValueError as exc:
+        assert str(exc) == "Debate payload must include a 'scenario' object."
+    else:
+        raise AssertionError("Expected ValueError for missing scenario payload")
+
+
 def test_debate_returns_insufficient_evidence_when_award_retrieval_is_empty(monkeypatch):
     class _EmptyRetriever:
         async def retrieve(self, query: str, top_k: int = 3):

--- a/backend/src/FairWorkly.API/Controllers/FairBot/FairBotController.cs
+++ b/backend/src/FairWorkly.API/Controllers/FairBot/FairBotController.cs
@@ -93,6 +93,9 @@ public class FairBotController(
         if (currentUser.UserId is not { } userId || userId == Guid.Empty)
             return RespondResult(Result<object>.Of401("Invalid user token"));
 
+        if (currentUser.OrganizationId is not { } organizationId || organizationId == Guid.Empty)
+            return RespondResult(Result<object>.Of401("Invalid user token"));
+
         try
         {
             var result = await aiClient.PostAsync<object, object>(

--- a/backend/src/FairWorkly.API/Controllers/FairBot/FairBotController.cs
+++ b/backend/src/FairWorkly.API/Controllers/FairBot/FairBotController.cs
@@ -15,8 +15,11 @@ namespace FairWorkly.API.Controllers.FairBot;
 /// </summary>
 [Route("api/fairbot")]
 [Authorize(Policy = "RequireAdmin")]
-public class FairBotController(IMediator mediator, ICurrentUserService currentUser)
-    : BaseApiController
+public class FairBotController(
+    IMediator mediator,
+    ICurrentUserService currentUser,
+    IAiClient aiClient
+) : BaseApiController
 {
     private const int MaxRequestIdLength = 128;
     private static readonly Regex ValidRequestIdPattern = new(
@@ -75,6 +78,34 @@ public class FairBotController(IMediator mediator, ICurrentUserService currentUs
 
         var result = await mediator.Send(command, cancellationToken);
         return RespondResult(result);
+    }
+
+    /// <summary>
+    /// Multi-agent compliance debate — proxies to Agent Service.
+    /// Three AI agents evaluate a shift scenario and deliver a final ruling.
+    /// </summary>
+    [HttpPost("debate")]
+    public async Task<IActionResult> Debate(
+        [FromBody] object request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (currentUser.UserId is not { } userId || userId == Guid.Empty)
+            return RespondResult(Result<object>.Of401("Invalid user token"));
+
+        try
+        {
+            var result = await aiClient.PostAsync<object, object>(
+                "/api/agent/debate",
+                request,
+                cancellationToken
+            );
+            return Ok(result);
+        }
+        catch (HttpRequestException ex)
+        {
+            return StatusCode(502, new { code = 502, msg = ex.Message });
+        }
     }
 
     private static string? SanitizeRequestId(string? raw)

--- a/frontend/src/app/routes/fairbot.routes.tsx
+++ b/frontend/src/app/routes/fairbot.routes.tsx
@@ -2,7 +2,6 @@ import { type RouteObject } from 'react-router-dom'
 import { ProtectedRoute } from '@/shared/components/guards/ProtectedRoute'
 import { RoleBasedRoute } from '@/shared/components/guards/RoleBasedRoute'
 import { MainLayout } from '@/shared/components/layout/app/MainLayout'
-import { FairBotPage } from '@/modules/fairbot/pages/FairBotPage'
 
 export const fairbotRoutes: RouteObject[] = [
   {
@@ -17,7 +16,21 @@ export const fairbotRoutes: RouteObject[] = [
             children: [
               {
                 path: '/fairbot',
-                element: <FairBotPage />,
+                lazy: async () => {
+                  const { FairBotPage } = await import(
+                    '@/modules/fairbot/pages/FairBotPage'
+                  )
+                  return { Component: FairBotPage }
+                },
+              },
+              {
+                path: '/debate',
+                lazy: async () => {
+                  const { DebatePage } = await import(
+                    '@/modules/fairbot/features/debate'
+                  )
+                  return { Component: DebatePage }
+                },
               },
             ],
           },

--- a/frontend/src/modules/fairbot/components/ActionCards.tsx
+++ b/frontend/src/modules/fairbot/components/ActionCards.tsx
@@ -5,13 +5,20 @@ import Typography from '@mui/material/Typography'
 import Box from '@mui/material/Box'
 import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined'
 import PaymentsOutlinedIcon from '@mui/icons-material/PaymentsOutlined'
+import GavelOutlinedIcon from '@mui/icons-material/GavelOutlined'
 import { alpha } from '@mui/material/styles'
-import { FAIRBOT_ARIA, FAIRBOT_ACTION_CARDS } from '../constants/fairbot.constants'
+import {
+  FAIRBOT_ARIA,
+  FAIRBOT_ACTION_CARDS,
+} from '../constants/fairbot.constants'
 
 const CardsGrid = styled('section')(({ theme }) => ({
   display: 'grid',
-  gridTemplateColumns: 'repeat(2, 1fr)',
+  gridTemplateColumns: 'repeat(3, 1fr)',
   gap: theme.spacing(2),
+  [theme.breakpoints.down('md')]: {
+    gridTemplateColumns: 'repeat(2, 1fr)',
+  },
   [theme.breakpoints.down('sm')]: {
     gridTemplateColumns: '1fr',
   },
@@ -26,9 +33,12 @@ const Card = styled(Paper)(({ theme }) => ({
   border: `1px solid ${theme.palette.divider}`,
   boxShadow: theme.fairworkly.shadow.sm,
   cursor: 'pointer',
-  transition: theme.transitions.create(['border-color', 'box-shadow', 'transform'], {
-    duration: theme.transitions.duration.short,
-  }),
+  transition: theme.transitions.create(
+    ['border-color', 'box-shadow', 'transform'],
+    {
+      duration: theme.transitions.duration.short,
+    }
+  ),
   '&:hover': {
     borderColor: alpha(theme.palette.primary.main, 0.3),
     boxShadow: theme.fairworkly.shadow.md,
@@ -57,13 +67,23 @@ const PayrollIconBox = styled(IconBox)(({ theme }) => ({
   color: theme.palette.success.main,
 }))
 
+const DebateIconBox = styled(IconBox)(({ theme }) => ({
+  background: alpha(theme.palette.warning.main, 0.08),
+  border: `1px solid ${alpha(theme.palette.warning.main, 0.1)}`,
+  color: theme.palette.warning.main,
+}))
+
 const CardContent = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(0.5),
 }))
 
-export const ActionCards = () => {
+interface ActionCardsProps {
+  onDebateClick?: () => void
+}
+
+export const ActionCards = ({ onDebateClick }: ActionCardsProps) => {
   const navigate = useNavigate()
 
   return (
@@ -72,7 +92,7 @@ export const ActionCards = () => {
         onClick={() => navigate(FAIRBOT_ACTION_CARDS.ROSTER.route)}
         role="button"
         tabIndex={0}
-        onKeyDown={(e) => {
+        onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             navigate(FAIRBOT_ACTION_CARDS.ROSTER.route)
@@ -96,7 +116,7 @@ export const ActionCards = () => {
         onClick={() => navigate(FAIRBOT_ACTION_CARDS.PAYROLL.route)}
         role="button"
         tabIndex={0}
-        onKeyDown={(e) => {
+        onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             navigate(FAIRBOT_ACTION_CARDS.PAYROLL.route)
@@ -112,6 +132,30 @@ export const ActionCards = () => {
           </Typography>
           <Typography variant="body2" color="text.secondary">
             {FAIRBOT_ACTION_CARDS.PAYROLL.description}
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Card
+        onClick={() => onDebateClick?.()}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onDebateClick?.()
+          }
+        }}
+      >
+        <DebateIconBox>
+          <GavelOutlinedIcon />
+        </DebateIconBox>
+        <CardContent>
+          <Typography variant="subtitle1" fontWeight="bold">
+            {FAIRBOT_ACTION_CARDS.DEBATE.title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {FAIRBOT_ACTION_CARDS.DEBATE.description}
           </Typography>
         </CardContent>
       </Card>

--- a/frontend/src/modules/fairbot/components/ChatSection.tsx
+++ b/frontend/src/modules/fairbot/components/ChatSection.tsx
@@ -38,8 +38,15 @@ const StatusArea = styled('div')(({ theme }) => ({
   padding: theme.spacing(2, 3, 0),
 }))
 
-export const ChatSection = () => {
-  const conversation = useConversation()
+interface ChatSectionProps {
+  conversationOverride?: ReturnType<typeof useConversation>
+}
+
+export const ChatSection = ({
+  conversationOverride,
+}: ChatSectionProps = {}) => {
+  const internalConversation = useConversation()
+  const conversation = conversationOverride ?? internalConversation
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const handleQuickFollowUp = (prompt: string) => {

--- a/frontend/src/modules/fairbot/components/MessageBubble.tsx
+++ b/frontend/src/modules/fairbot/components/MessageBubble.tsx
@@ -4,6 +4,7 @@ import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import { FAIRBOT_ROLES } from '../constants/fairbot.constants'
 import type { FairBotMessage } from '../types/fairbot.types'
+import { InlineDebateTimeline } from '../features/debate/InlineDebateTimeline'
 
 interface MessageBubbleProps {
   message: FairBotMessage
@@ -136,6 +137,7 @@ export const MessageBubble = ({
   const metadata = message.metadata
   const sources = metadata?.sources?.slice(0, 5) ?? []
   const actionPlan = showActionPlan ? metadata?.actionPlan : undefined
+  const debateResult = metadata?.debateResult
   const hasDetails =
     !isUser &&
     (metadata?.model || metadata?.note || sources.length > 0 || actionPlan)
@@ -148,10 +150,15 @@ export const MessageBubble = ({
           Sent {formatTimestamp(message.timestamp)}
         </Typography>
       </MetaRow>
-      <Bubble isUser={isUser}>
+      <Bubble isUser={isUser} sx={debateResult ? { maxWidth: 600 } : undefined}>
         <Typography variant="body2" whiteSpace="pre-line">
           {message.text}
         </Typography>
+        {debateResult && (
+          <DetailSection>
+            <InlineDebateTimeline result={debateResult} />
+          </DetailSection>
+        )}
         {hasDetails && (
           <DetailSection>
             {metadata?.model && (

--- a/frontend/src/modules/fairbot/constants/fairbot.constants.ts
+++ b/frontend/src/modules/fairbot/constants/fairbot.constants.ts
@@ -23,4 +23,11 @@ export const FAIRBOT_ACTION_CARDS = {
     description: 'Upload payslip CSV to check for underpayment risks',
     route: '/payroll',
   },
+  DEBATE: {
+    id: 'agent-debate',
+    title: 'Agent Debate',
+    description:
+      'Watch three AI agents debate a compliance scenario and deliver a ruling',
+    route: '/debate',
+  },
 } as const

--- a/frontend/src/modules/fairbot/features/debate/DebatePage.tsx
+++ b/frontend/src/modules/fairbot/features/debate/DebatePage.tsx
@@ -1,0 +1,66 @@
+import Typography from '@mui/material/Typography'
+import Alert from '@mui/material/Alert'
+import LinearProgress from '@mui/material/LinearProgress'
+import { styled } from '@/styles/styled'
+import { DebateScenarioForm } from './DebateScenarioForm'
+import { DebateTimeline } from './DebateTimeline'
+import { useDebate } from './useDebate'
+
+const PageContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(4),
+  maxWidth: 800,
+  margin: '0 auto',
+  padding: theme.spacing(4, 2),
+}))
+
+const Header = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(1),
+}))
+
+const Section = styled('div')(({ theme }) => ({
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.fairworkly.radius.lg,
+  backgroundColor: theme.palette.background.paper,
+  padding: theme.spacing(3),
+  boxShadow: theme.fairworkly.shadow.sm,
+}))
+
+export const DebatePage = () => {
+  const { result, isLoading, error, startDebate } = useDebate()
+
+  return (
+    <PageContainer>
+      <Header>
+        <Typography variant="h4">Multi-Agent Compliance Debate</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Three AI agents review a shift scenario, challenge each other's
+          analysis, and deliver a final ruling backed by Award legislation.
+        </Typography>
+      </Header>
+
+      <Section>
+        <Typography variant="subtitle2" sx={{ mb: 2 }}>
+          Shift Scenario
+        </Typography>
+        <DebateScenarioForm onSubmit={startDebate} isLoading={isLoading} />
+      </Section>
+
+      {isLoading && <LinearProgress />}
+
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {result && (
+        <Section>
+          <Typography variant="subtitle2" sx={{ mb: 2.5 }}>
+            Agent Debate
+          </Typography>
+          <DebateTimeline result={result} />
+        </Section>
+      )}
+    </PageContainer>
+  )
+}

--- a/frontend/src/modules/fairbot/features/debate/DebateScenarioForm.tsx
+++ b/frontend/src/modules/fairbot/features/debate/DebateScenarioForm.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import { styled } from '@/styles/styled'
+import type { ShiftScenario } from '../../types/debate.types'
+
+interface DebateScenarioFormProps {
+  onSubmit: (scenario: ShiftScenario) => void
+  isLoading: boolean
+}
+
+const FormGrid = styled('form')(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: theme.spacing(2),
+  [theme.breakpoints.down('sm')]: {
+    gridTemplateColumns: '1fr',
+  },
+}))
+
+const FullWidth = styled('div')({
+  gridColumn: '1 / -1',
+})
+
+const DEFAULT_SCENARIO: ShiftScenario = {
+  employee_name: 'Alice',
+  shift_date: '2024-03-16 (Saturday)',
+  shift_hours: 10,
+  week_hours_before_shift: 38,
+  award_name: 'Hospitality Industry (General) Award 2020',
+  extra_context: 'Full-time employee',
+}
+
+export const DebateScenarioForm = ({
+  onSubmit,
+  isLoading,
+}: DebateScenarioFormProps) => {
+  const [form, setForm] = useState<ShiftScenario>(DEFAULT_SCENARIO)
+
+  const update = (field: keyof ShiftScenario, value: string | number) =>
+    setForm(prev => ({ ...prev, [field]: value }))
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit(form)
+  }
+
+  return (
+    <FormGrid onSubmit={handleSubmit}>
+      <TextField
+        label="Employee Name"
+        size="small"
+        value={form.employee_name}
+        onChange={e => update('employee_name', e.target.value)}
+        required
+      />
+      <TextField
+        label="Shift Date"
+        size="small"
+        value={form.shift_date}
+        onChange={e => update('shift_date', e.target.value)}
+        required
+        helperText="e.g. 2024-03-16 (Saturday)"
+      />
+      <TextField
+        label="Shift Hours"
+        size="small"
+        type="number"
+        value={form.shift_hours}
+        onChange={e => update('shift_hours', Number(e.target.value))}
+        required
+        inputProps={{ min: 0, max: 24, step: 0.5 }}
+      />
+      <TextField
+        label="Week Hours Before Shift"
+        size="small"
+        type="number"
+        value={form.week_hours_before_shift}
+        onChange={e =>
+          update('week_hours_before_shift', Number(e.target.value))
+        }
+        required
+        inputProps={{ min: 0, max: 100, step: 0.5 }}
+        helperText="Hours already worked Mon-Fri"
+      />
+      <FullWidth>
+        <TextField
+          label="Applicable Award"
+          size="small"
+          fullWidth
+          value={form.award_name}
+          onChange={e => update('award_name', e.target.value)}
+          required
+        />
+      </FullWidth>
+      <FullWidth>
+        <TextField
+          label="Additional Context (optional)"
+          size="small"
+          fullWidth
+          value={form.extra_context ?? ''}
+          onChange={e => update('extra_context', e.target.value)}
+        />
+      </FullWidth>
+      <FullWidth>
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={isLoading}
+          startIcon={<PlayArrowIcon />}
+          sx={{ mt: 1 }}
+        >
+          {isLoading ? 'Agents are debating...' : 'Start Agent Debate'}
+        </Button>
+        {isLoading && (
+          <Typography variant="caption" color="text.secondary" sx={{ ml: 2 }}>
+            Three agents are reviewing the scenario — this may take 15-30
+            seconds.
+          </Typography>
+        )}
+      </FullWidth>
+    </FormGrid>
+  )
+}

--- a/frontend/src/modules/fairbot/features/debate/DebateTimeline.tsx
+++ b/frontend/src/modules/fairbot/features/debate/DebateTimeline.tsx
@@ -143,7 +143,7 @@ export const DebateTimeline = ({ result }: DebateTimelineProps) => {
                   <Chip
                     key={`${src.source}-${src.page}-${i}`}
                     size="small"
-                    label={`${src.source} p.${src.page + 1}`}
+                    label={`${src.source}${src.page != null ? ` p.${src.page + 1}` : ''}`}
                     variant="outlined"
                   />
                 ))}

--- a/frontend/src/modules/fairbot/features/debate/DebateTimeline.tsx
+++ b/frontend/src/modules/fairbot/features/debate/DebateTimeline.tsx
@@ -1,0 +1,185 @@
+import Typography from '@mui/material/Typography'
+import Chip from '@mui/material/Chip'
+import GavelIcon from '@mui/icons-material/Gavel'
+import { styled } from '@/styles/styled'
+import type { DebateResult } from '../../types/debate.types'
+
+interface DebateTimelineProps {
+  result: DebateResult
+}
+
+/* ── Styled components ─────────────────────────────────── */
+
+const Root = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 0,
+  position: 'relative',
+})
+
+const RoundRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(2),
+  position: 'relative',
+}))
+
+const TimelineTrack = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  width: 48,
+  flexShrink: 0,
+})
+
+const IconCircle = styled('div')(({ theme }) => ({
+  width: 40,
+  height: 40,
+  borderRadius: '50%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: 20,
+  backgroundColor: theme.palette.background.paper,
+  border: `2px solid ${theme.palette.divider}`,
+  position: 'relative',
+  zIndex: 1,
+}))
+
+const Connector = styled('div')(({ theme }) => ({
+  width: 2,
+  flex: 1,
+  minHeight: 24,
+  backgroundColor: theme.palette.divider,
+}))
+
+const RoundCard = styled('div')(({ theme }) => ({
+  flex: 1,
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.fairworkly.radius.lg,
+  backgroundColor: theme.palette.background.paper,
+  padding: theme.spacing(2),
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(1.25),
+  marginBottom: theme.spacing(2),
+  boxShadow: theme.fairworkly.shadow.sm,
+}))
+
+const AgentHeader = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+}))
+
+const ChallengeBar = styled('div')(({ theme }) => ({
+  borderLeft: `3px solid ${theme.palette.warning.main}`,
+  paddingLeft: theme.spacing(1.5),
+  backgroundColor: 'rgba(249, 115, 22, 0.06)',
+  borderRadius: `0 ${theme.fairworkly.radius.sm}px ${theme.fairworkly.radius.sm}px 0`,
+  padding: theme.spacing(1, 1.5),
+}))
+
+const SourcesRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: theme.spacing(0.5),
+}))
+
+const VerdictCard = styled('div')(({ theme }) => ({
+  border: `2px solid ${theme.palette.success.main}`,
+  borderRadius: theme.fairworkly.radius.lg,
+  backgroundColor: 'rgba(16, 185, 129, 0.06)',
+  padding: theme.spacing(2.5),
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(1.25),
+  boxShadow: theme.fairworkly.shadow.md,
+}))
+
+/* ── Component ─────────────────────────────────────────── */
+
+export const DebateTimeline = ({ result }: DebateTimelineProps) => {
+  const { rounds, final_ruling, cited_award_section, model } = result
+
+  return (
+    <Root>
+      {rounds.map((round, idx) => (
+        <RoundRow key={round.agent}>
+          <TimelineTrack>
+            <IconCircle>{round.icon}</IconCircle>
+            {idx < rounds.length - 1 && <Connector />}
+          </TimelineTrack>
+
+          <RoundCard>
+            <AgentHeader>
+              <Typography variant="subtitle2">{round.agent}</Typography>
+              <Chip
+                size="small"
+                label={round.role}
+                variant="outlined"
+                color={idx === 0 ? 'info' : idx === 1 ? 'warning' : 'success'}
+              />
+            </AgentHeader>
+
+            <Typography variant="body2" fontWeight={700}>
+              {round.stance}
+            </Typography>
+
+            {round.challenges && (
+              <ChallengeBar>
+                <Typography variant="caption" color="warning.dark">
+                  {round.challenges}
+                </Typography>
+              </ChallengeBar>
+            )}
+
+            <Typography variant="body2" color="text.secondary">
+              {round.reasoning}
+            </Typography>
+
+            {round.sources.length > 0 && (
+              <SourcesRow>
+                {round.sources.map((src, i) => (
+                  <Chip
+                    key={`${src.source}-${src.page}-${i}`}
+                    size="small"
+                    label={`${src.source} p.${src.page + 1}`}
+                    variant="outlined"
+                  />
+                ))}
+              </SourcesRow>
+            )}
+          </RoundCard>
+        </RoundRow>
+      ))}
+
+      {/* Final ruling */}
+      <RoundRow>
+        <TimelineTrack>
+          <IconCircle>
+            <GavelIcon fontSize="small" color="success" />
+          </IconCircle>
+        </TimelineTrack>
+
+        <VerdictCard>
+          <Typography variant="subtitle1" color="success.dark">
+            Final Ruling
+          </Typography>
+          <Typography variant="body1" fontWeight={700}>
+            {final_ruling}
+          </Typography>
+          {cited_award_section && (
+            <Typography variant="caption" color="text.secondary">
+              Cited: {cited_award_section}
+            </Typography>
+          )}
+          {model && (
+            <Typography variant="caption" color="text.disabled">
+              Model: {model}
+            </Typography>
+          )}
+        </VerdictCard>
+      </RoundRow>
+    </Root>
+  )
+}

--- a/frontend/src/modules/fairbot/features/debate/InlineDebateTimeline.tsx
+++ b/frontend/src/modules/fairbot/features/debate/InlineDebateTimeline.tsx
@@ -1,0 +1,155 @@
+import Typography from '@mui/material/Typography'
+import Chip from '@mui/material/Chip'
+import GavelIcon from '@mui/icons-material/Gavel'
+import { styled } from '@/styles/styled'
+import type { FairBotDebateResult } from '../../types/fairbot.types'
+
+interface InlineDebateTimelineProps {
+  result: FairBotDebateResult
+}
+
+const Root = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 0,
+})
+
+const RoundRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(1.5),
+}))
+
+const Track = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  width: 36,
+  flexShrink: 0,
+})
+
+const Dot = styled('div')(({ theme }) => ({
+  width: 32,
+  height: 32,
+  borderRadius: '50%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: 16,
+  backgroundColor: theme.palette.background.default,
+  border: `2px solid ${theme.palette.divider}`,
+  zIndex: 1,
+}))
+
+const Line = styled('div')(({ theme }) => ({
+  width: 2,
+  flex: 1,
+  minHeight: 16,
+  backgroundColor: theme.palette.divider,
+}))
+
+const RoundBody = styled('div')(({ theme }) => ({
+  flex: 1,
+  paddingBottom: theme.spacing(1.5),
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(0.5),
+}))
+
+const ChallengeText = styled(Typography)(({ theme }) => ({
+  borderLeft: `3px solid ${theme.palette.warning.main}`,
+  paddingLeft: theme.spacing(1),
+  marginTop: theme.spacing(0.25),
+}))
+
+const VerdictBox = styled('div')(({ theme }) => ({
+  border: `2px solid ${theme.palette.success.main}`,
+  borderRadius: theme.fairworkly.radius.md,
+  backgroundColor: 'rgba(16, 185, 129, 0.06)',
+  padding: theme.spacing(1.5),
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(0.5),
+}))
+
+const SourceChips = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: theme.spacing(0.5),
+  marginTop: theme.spacing(0.25),
+}))
+
+export const InlineDebateTimeline = ({ result }: InlineDebateTimelineProps) => {
+  const { rounds, final_ruling, cited_award_section } = result
+
+  return (
+    <Root>
+      {rounds.map((round, idx) => (
+        <RoundRow key={round.agent}>
+          <Track>
+            <Dot>{round.icon}</Dot>
+            {idx < rounds.length && <Line />}
+          </Track>
+          <RoundBody>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <Typography variant="caption" fontWeight={700}>
+                {round.agent}
+              </Typography>
+              <Chip
+                size="small"
+                label={round.role}
+                variant="outlined"
+                color={idx === 0 ? 'info' : idx === 1 ? 'warning' : 'success'}
+                sx={{ height: 20, fontSize: 11 }}
+              />
+            </div>
+            <Typography variant="body2" fontWeight={600}>
+              {round.stance}
+            </Typography>
+            {round.challenges && (
+              <ChallengeText variant="caption" color="warning.dark">
+                {round.challenges}
+              </ChallengeText>
+            )}
+            <Typography variant="caption" color="text.secondary">
+              {round.reasoning}
+            </Typography>
+            {round.sources.length > 0 && (
+              <SourceChips>
+                {round.sources.map((src, i) => (
+                  <Chip
+                    key={`${src.source}-${src.page}-${i}`}
+                    size="small"
+                    label={`${src.source} p.${(src.page ?? 0) + 1}`}
+                    variant="outlined"
+                    sx={{ height: 20, fontSize: 10 }}
+                  />
+                ))}
+              </SourceChips>
+            )}
+          </RoundBody>
+        </RoundRow>
+      ))}
+
+      <RoundRow>
+        <Track>
+          <Dot>
+            <GavelIcon sx={{ fontSize: 16 }} color="success" />
+          </Dot>
+        </Track>
+        <VerdictBox>
+          <Typography variant="caption" fontWeight={700} color="success.dark">
+            Final Ruling
+          </Typography>
+          <Typography variant="body2" fontWeight={700}>
+            {final_ruling}
+          </Typography>
+          {cited_award_section && (
+            <Typography variant="caption" color="text.secondary">
+              Cited: {cited_award_section}
+            </Typography>
+          )}
+        </VerdictBox>
+      </RoundRow>
+    </Root>
+  )
+}

--- a/frontend/src/modules/fairbot/features/debate/index.ts
+++ b/frontend/src/modules/fairbot/features/debate/index.ts
@@ -1,0 +1,1 @@
+export { DebatePage } from './DebatePage'

--- a/frontend/src/modules/fairbot/features/debate/useDebate.ts
+++ b/frontend/src/modules/fairbot/features/debate/useDebate.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { runDebate } from '@/services/debateApi'
+import type { ShiftScenario, DebateResult } from '../../types/debate.types'
+
+export const useDebate = () => {
+  const [result, setResult] = useState<DebateResult | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const startDebate = async (scenario: ShiftScenario) => {
+    setIsLoading(true)
+    setError(null)
+    setResult(null)
+    try {
+      const data = await runDebate(scenario)
+      setResult(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { result, isLoading, error, startDebate }
+}

--- a/frontend/src/modules/fairbot/hooks/useFairBotChat.ts
+++ b/frontend/src/modules/fairbot/hooks/useFairBotChat.ts
@@ -210,7 +210,7 @@ export const useFairBotChat = (): UseFairBotChatResult => {
 
   const [isDebating, setIsDebating] = useState(false)
 
-  const sendDebate = useCallback(async (_text: string): Promise<boolean> => {
+  const sendDebate = useCallback(async (): Promise<boolean> => {
     setIsDebating(true)
     try {
       const debateResult = await runDebate({
@@ -255,7 +255,7 @@ export const useFairBotChat = (): UseFairBotChatResult => {
 
       // Intercept /debate command — route to multi-agent debate
       if (trimmedText.startsWith('/debate')) {
-        return sendDebate(trimmedText)
+        return sendDebate()
       }
 
       const historyPayload = toHistoryPayload(messages)

--- a/frontend/src/modules/fairbot/hooks/useFairBotChat.ts
+++ b/frontend/src/modules/fairbot/hooks/useFairBotChat.ts
@@ -6,6 +6,7 @@ import {
   type AgentChatResponse,
   type AgentChatHistoryItem,
 } from '@/services/fairbotApi'
+import { runDebate } from '@/services/debateApi'
 import { useAuth } from '@/modules/auth/hooks/useAuth'
 import { getValidationResults } from '@/services/rosterApi'
 import { useApiMutation } from '@/shared/hooks/useApiMutation'
@@ -207,6 +208,39 @@ export const useFairBotChat = (): UseFairBotChatResult => {
     }
   }, [])
 
+  const [isDebating, setIsDebating] = useState(false)
+
+  const sendDebate = useCallback(async (_text: string): Promise<boolean> => {
+    setIsDebating(true)
+    try {
+      const debateResult = await runDebate({
+        employee_name: 'Alice',
+        shift_date: '2024-03-16 (Saturday)',
+        shift_hours: 10,
+        week_hours_before_shift: 38,
+        award_name: 'Hospitality Industry (General) Award 2020',
+        extra_context: 'Full-time employee',
+      })
+
+      const assistantMessage = createMessage(
+        FAIRBOT_ROLES.ASSISTANT,
+        'Here is the multi-agent compliance debate result:',
+        {
+          model: debateResult.model ?? undefined,
+          debateResult,
+        }
+      )
+      setMessages(prev => [...prev, assistantMessage])
+      return true
+    } catch (caughtError) {
+      const normalized = createChatError(caughtError)
+      setError(normalized)
+      return false
+    } finally {
+      setIsDebating(false)
+    }
+  }, [])
+
   const sendMessage = useCallback(
     async (text: string): Promise<boolean> => {
       const trimmedText = text.trim()
@@ -216,9 +250,15 @@ export const useFairBotChat = (): UseFairBotChatResult => {
 
       setError(null)
 
-      const historyPayload = toHistoryPayload(messages)
       const userMessage = createMessage(FAIRBOT_ROLES.USER, trimmedText)
       setMessages(prev => [...prev, userMessage])
+
+      // Intercept /debate command — route to multi-agent debate
+      if (trimmedText.startsWith('/debate')) {
+        return sendDebate(trimmedText)
+      }
+
+      const historyPayload = toHistoryPayload(messages)
 
       runtimeRef.current.abortController?.abort()
       const controller = new AbortController()
@@ -264,14 +304,14 @@ export const useFairBotChat = (): UseFairBotChatResult => {
         }
       }
     },
-    [context, messages, sendChat]
+    [context, messages, sendChat, sendDebate]
   )
 
   return useMemo(
     () => ({
       messages,
       sendMessage,
-      isLoading: isSending,
+      isLoading: isSending || isDebating,
       error,
       contextLabel: isRosterExplainMode
         ? isContextLoading
@@ -286,6 +326,7 @@ export const useFairBotChat = (): UseFairBotChatResult => {
       messages,
       sendMessage,
       isSending,
+      isDebating,
       error,
       context,
       isRosterExplainMode,

--- a/frontend/src/modules/fairbot/pages/FairBotPage.tsx
+++ b/frontend/src/modules/fairbot/pages/FairBotPage.tsx
@@ -1,7 +1,12 @@
+import { useCallback } from 'react'
 import { styled } from '@/styles/styled'
 import { WelcomeHeader } from '../components/WelcomeHeader'
 import { ActionCards } from '../components/ActionCards'
 import { ChatSection } from '../components/ChatSection'
+import { useConversation } from '../hooks/useConversation'
+
+const DEBATE_TRIGGER =
+  '/debate Alice worked 10 hours on Saturday. She already worked 38 hours this week. Full-time employee under the Hospitality Industry (General) Award 2020. What is the correct pay rate?'
 
 const PageContainer = styled('div')(({ theme }) => ({
   display: 'flex',
@@ -10,10 +15,18 @@ const PageContainer = styled('div')(({ theme }) => ({
   height: '100%',
 }))
 
-export const FairBotPage = () => (
-  <PageContainer>
-    <WelcomeHeader />
-    <ActionCards />
-    <ChatSection />
-  </PageContainer>
-)
+export const FairBotPage = () => {
+  const conversation = useConversation()
+
+  const handleDebateClick = useCallback(() => {
+    void conversation.sendMessage(DEBATE_TRIGGER)
+  }, [conversation.sendMessage])
+
+  return (
+    <PageContainer>
+      <WelcomeHeader />
+      <ActionCards onDebateClick={handleDebateClick} />
+      <ChatSection conversationOverride={conversation} />
+    </PageContainer>
+  )
+}

--- a/frontend/src/modules/fairbot/pages/FairBotPage.tsx
+++ b/frontend/src/modules/fairbot/pages/FairBotPage.tsx
@@ -17,10 +17,11 @@ const PageContainer = styled('div')(({ theme }) => ({
 
 export const FairBotPage = () => {
   const conversation = useConversation()
+  const { sendMessage } = conversation
 
   const handleDebateClick = useCallback(() => {
-    void conversation.sendMessage(DEBATE_TRIGGER)
-  }, [conversation.sendMessage])
+    void sendMessage(DEBATE_TRIGGER)
+  }, [sendMessage])
 
   return (
     <PageContainer>

--- a/frontend/src/modules/fairbot/types/debate.types.ts
+++ b/frontend/src/modules/fairbot/types/debate.types.ts
@@ -1,0 +1,38 @@
+export interface ShiftScenario {
+  employee_name: string
+  shift_date: string
+  shift_hours: number
+  week_hours_before_shift: number
+  award_name: string
+  extra_context?: string
+}
+
+export interface DebateSource {
+  source: string
+  page: number
+  content?: string
+}
+
+export interface DebateRound {
+  agent: string
+  role: string
+  icon: string
+  stance: string
+  reasoning: string
+  challenges: string | null
+  sources: DebateSource[]
+}
+
+export interface DebateResult {
+  scenario_summary: string
+  rounds: DebateRound[]
+  final_ruling: string
+  cited_award_section: string | null
+  model: string | null
+}
+
+export interface DebateApiResponse {
+  code: number
+  msg: string
+  data: DebateResult
+}

--- a/frontend/src/modules/fairbot/types/fairbot.types.ts
+++ b/frontend/src/modules/fairbot/types/fairbot.types.ts
@@ -43,11 +43,30 @@ export interface FairBotActionPlan {
   quickFollowUps: FairBotActionFollowUp[]
 }
 
+export interface FairBotDebateRound {
+  agent: string
+  role: string
+  icon: string
+  stance: string
+  reasoning: string
+  challenges: string | null
+  sources: FairBotMessageSource[]
+}
+
+export interface FairBotDebateResult {
+  scenario_summary: string
+  rounds: FairBotDebateRound[]
+  final_ruling: string
+  cited_award_section: string | null
+  model: string | null
+}
+
 export interface FairBotMessageMetadata {
   model?: string
   note?: string | null
   sources?: FairBotMessageSource[]
   actionPlan?: FairBotActionPlan
+  debateResult?: FairBotDebateResult
 }
 
 // Chat message model used across UI and session storage.

--- a/frontend/src/services/debateApi.ts
+++ b/frontend/src/services/debateApi.ts
@@ -1,0 +1,19 @@
+import httpClient from './httpClient'
+import type {
+  ShiftScenario,
+  DebateResult,
+} from '@/modules/fairbot/types/debate.types'
+
+export async function runDebate(
+  scenario: ShiftScenario
+): Promise<DebateResult> {
+  // Backend proxies to agent service and returns { code, msg, data }.
+  // setupInterceptors unwraps the envelope, so response.data is the inner
+  // DebateResult directly (the agent service's data field).
+  const response = await httpClient.post<DebateResult>(
+    '/fairbot/debate',
+    { scenario },
+    { timeout: 120_000 }
+  )
+  return response.data
+}


### PR DESCRIPTION
## Summary

Adds a three-agent compliance debate system where LLM agents sequentially evaluate a shift scenario, challenge each other's reasoning, and arrive at an auditable verdict grounded in retrieved Award legislation. Users trigger it from a new "Agent Debate" action card inside FairBot; the debate timeline is rendered inline in the chat stream.

## What's in this PR

**Agent Service (Python)**
- New `agents/debate/` package: orchestrator (`feature.py`), Pydantic models, and role-specific prompt templates for Roster Agent, Payroll Agent, and Fair Bot
- Sequential pipeline: Roster Agent (shallow per-shift assessment) → Payroll Agent (challenges with cumulative-hours + RAG) → Fair Bot (arbitrates and cites an Award section)
- Shared FAISS retrieval call across all three agents to ground every response in citeable Award excerpts
- New `POST /api/agent/debate` endpoint registered in `master_agent/main.py` and `intent_router.py`

**Backend (.NET)**
- New `POST /api/fairbot/debate` endpoint in `FairBotController` that proxies a JSON body to the Agent Service via `IAiClient.PostAsync<TReq, TRes>`
- Reuses the existing `RequireAdmin` authorization policy
- No new services or DTOs — stays intentionally thin

**Frontend (React / TS)**
- New `debate.types.ts` + `debateApi.ts` service
- `features/debate/` package with `DebatePage`, `DebateTimeline`, `DebateScenarioForm`, `useDebate` for a dedicated `/debate` route
- `InlineDebateTimeline` — compact variant that renders the debate inside a FairBot chat message bubble
- `useFairBotChat` now intercepts messages starting with `/debate` and calls the debate endpoint directly, embedding the `DebateResult` into the assistant message metadata
- `FairBotPage` lifts `useConversation` and passes it to `ChatSection` so the new Action Card can dispatch a preset debate trigger without leaving the page
- New "Agent Debate" card in `ActionCards` alongside Roster / Payroll
- Added `FairBotDebateResult` + `FairBotDebateRound` to `fairbot.types.ts`

## Architecture

Frontend (`/fairbot` → Agent Debate card) → .NET Backend (`POST /api/fairbot/debate`) → Agent Service (`POST /api/agent/debate`) → 3 sequential LLM calls with shared FAISS RAG retrieval → structured `DebateResult` returned all the way back and rendered inline.

## Test plan
- [ ] Backend builds clean (`dotnet build`)
- [ ] Frontend typechecks (`npx tsc --noEmit`)
- [ ] Agent service imports and starts without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent Debate: three AI agents analyze a shift scenario, cite award clauses, and produce a final ruling with sources.
  * New “Agent Debate” page: scenario form, loading state, results timeline, and inline timeline in chat message bubbles.
  * UI updates: Debate action card, lazy-loaded debate route, and keyboard-accessible Debate card trigger.
  * In-chat trigger/background flow to run debates and attach results to messages.

* **Chores**
  * Added a protected backend endpoint to proxy debate requests to the agent service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->