### PR TITLE
Fix roster results severity rendering

### DIFF
--- a/frontend/src/modules/roster/utils/mapValidationResponse.test.ts
+++ b/frontend/src/modules/roster/utils/mapValidationResponse.test.ts
@@ -181,6 +181,7 @@ describe('mapValidationToComplianceResults', () => {
     expect(issue.id).toBe(1)
     expect(issue.name).toBe('Alice Smith')
     expect(issue.empId).toBe('E001')
+    expect(issue.severity).toBe('Error')
     expect(issue.expectedValue).toBe('3 hrs')
     expect(issue.actualValue).toBe('2 hrs')
     expect(issue.reason).toBe('Shift only 2 hours, minimum is 3 hours')
@@ -198,6 +199,81 @@ describe('mapValidationToComplianceResults', () => {
     expect(result.categories).toHaveLength(0)
     expect(result.summary.employeesCompliant).toBe(5)
     expect(result.summary.employeesAffected).toBe(0)
+  })
+
+  it('counts both Critical and Error severities as critical issues', () => {
+    const response = createBaseResponse({
+      issues: [
+        {
+          id: '1',
+          shiftId: null,
+          employeeId: 'emp-1',
+          employeeName: 'Alice',
+          employeeNumber: 'E001',
+          checkType: 'MinimumShiftHours',
+          severity: 'Critical',
+          description: 'Critical issue',
+          expectedValue: 3,
+          actualValue: 1,
+          affectedDates: null,
+        },
+        {
+          id: '2',
+          shiftId: null,
+          employeeId: 'emp-2',
+          employeeName: 'Bob',
+          employeeNumber: 'E002',
+          checkType: 'MealBreak',
+          severity: 'Error',
+          description: 'Error issue',
+          expectedValue: null,
+          actualValue: 0,
+          affectedDates: null,
+        },
+        {
+          id: '3',
+          shiftId: null,
+          employeeId: 'emp-3',
+          employeeName: 'Cara',
+          employeeNumber: 'E003',
+          checkType: 'WeeklyHoursLimit',
+          severity: 'Warning',
+          description: 'Warning issue',
+          expectedValue: 38,
+          actualValue: 40,
+          affectedDates: null,
+        },
+      ],
+    })
+
+    const result = mapValidationToComplianceResults(response)
+
+    expect(result.summary.criticalIssuesCount).toBe(2)
+  })
+
+  it('normalizes unknown severities to Error', () => {
+    const response = createBaseResponse({
+      issues: [
+        {
+          id: '1',
+          shiftId: null,
+          employeeId: 'emp-1',
+          employeeName: 'Alice',
+          employeeNumber: 'E001',
+          checkType: 'MinimumShiftHours',
+          severity: 'UnexpectedSeverity',
+          description: 'Unexpected severity from backend',
+          expectedValue: 3,
+          actualValue: 2,
+          affectedDates: null,
+        },
+      ],
+    })
+
+    const result = mapValidationToComplianceResults(response)
+
+    expect(result.categories[0].issues[0].severity).toBe('Error')
+    expect(result.summary.criticalIssuesCount).toBe(1)
   })
 
   it('handles unknown checkType with fallback display', () => {

--- a/frontend/src/modules/roster/utils/mapValidationResponse.ts
+++ b/frontend/src/modules/roster/utils/mapValidationResponse.ts
@@ -6,6 +6,7 @@ import type {
   ValidationMetadata,
   ValidationSummary,
   IssueCategory,
+  IssueSeverity,
 } from '@/shared/compliance-check'
 import { checkTypeDisplayMap } from '../config/checkTypeDisplay'
 
@@ -13,6 +14,23 @@ export interface RosterComplianceResults {
   metadata: ValidationMetadata
   summary: ValidationSummary
   categories: IssueCategory[]
+}
+
+const severityRank: Record<IssueSeverity, number> = {
+  Info: 0,
+  Warning: 1,
+  Error: 2,
+  Critical: 3,
+}
+
+const issueSeverities = ['Info', 'Warning', 'Error', 'Critical'] as const
+
+function isIssueSeverity(value: string): value is IssueSeverity {
+  return issueSeverities.includes(value as IssueSeverity)
+}
+
+function normalizeIssueSeverity(value: string): IssueSeverity {
+  return isIssueSeverity(value) ? value : 'Error'
 }
 
 /**
@@ -67,18 +85,23 @@ export function mapValidationToComplianceResults(
       color: display.color,
       employeeCount: uniqueEmployees.size,
       totalUnderpayment: `${issues.length} violation${issues.length !== 1 ? 's' : ''}`,
-      issues: issues.map(issue => ({
-        id: issueIdMap.get(issue.id)!,
-        name: issue.employeeName ?? 'Unknown',
-        empId: issue.employeeNumber ?? issue.employeeId.substring(0, 8),
-        actualValue: formatIssueValue(issue.actualValue, issue.checkType),
-        expectedValue: formatIssueValue(issue.expectedValue, issue.checkType),
-        reason: issue.description,
-        variance: computeVariance(issue),
-        breakdown: issue.affectedDates
-          ? `Affected date: ${issue.affectedDates}`
-          : '',
-      })),
+      issues: issues.map(issue => {
+        const severity = normalizeIssueSeverity(issue.severity)
+
+        return {
+          id: issueIdMap.get(issue.id)!,
+          name: issue.employeeName ?? 'Unknown',
+          empId: issue.employeeNumber ?? issue.employeeId.substring(0, 8),
+          severity,
+          actualValue: formatIssueValue(issue.actualValue, issue.checkType),
+          expectedValue: formatIssueValue(issue.expectedValue, issue.checkType),
+          reason: issue.description,
+          variance: computeVariance(issue),
+          breakdown: issue.affectedDates
+            ? `Affected date: ${issue.affectedDates}`
+            : '',
+        }
+      }),
     }
   })
 
@@ -106,8 +129,9 @@ export function mapValidationToComplianceResults(
   const summary: ValidationSummary = {
     employeesCompliant: compliantEmployees,
     totalIssues: complianceIssues.length,
-    criticalIssuesCount: complianceIssues.filter(i => i.severity === 'Error')
-      .length,
+    criticalIssuesCount: complianceIssues.filter(
+      i => severityRank[normalizeIssueSeverity(i.severity)] >= severityRank.Error
+    ).length,
     totalUnderpayment: 'N/A',
     employeesAffected: affectedEmployeeIds.size,
   }

--- a/frontend/src/shared/compliance-check/components/IssueRow.tsx
+++ b/frontend/src/shared/compliance-check/components/IssueRow.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Box, Typography, Checkbox, styled, alpha } from '@mui/material'
+import { Box, Typography, Checkbox, Chip, styled, alpha } from '@mui/material'
 import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined'
-import type { IssueItem } from '../types/complianceCheck.type'
+import type { IssueItem, IssueSeverity } from '../types/complianceCheck.type'
 
 const IssueRowWrapper = styled(Box)(({ theme }) => ({
   padding: theme.spacing(2),
@@ -24,9 +24,11 @@ const IssueRowWrapper = styled(Box)(({ theme }) => ({
   },
 }))
 
-const IssueAlert = styled(Box)(({ theme }) => ({
-  backgroundColor: alpha(theme.palette.error.main, 0.08),
-  borderLeft: `4px solid ${theme.palette.error.main}`,
+const IssueAlert = styled(Box, {
+  shouldForwardProp: prop => prop !== 'accentColor',
+})<{ accentColor: string }>(({ theme, accentColor }) => ({
+  backgroundColor: alpha(accentColor, 0.08),
+  borderLeft: `4px solid ${accentColor}`,
   borderRadius: theme.fairworkly.radius.sm,
   padding: theme.spacing(1.5),
   display: 'flex',
@@ -60,6 +62,17 @@ const EmployeeId = styled(Typography)(({ theme }) => ({
   flexShrink: 0,
 }))
 
+const SeverityChip = styled(Chip, {
+  shouldForwardProp: prop => prop !== 'chipColor',
+})<{ chipColor: string }>(({ chipColor }) => ({
+  height: 22,
+  fontSize: 11,
+  fontWeight: 600,
+  backgroundColor: alpha(chipColor, 0.1),
+  borderColor: alpha(chipColor, 0.3),
+  '& .MuiChip-label': { color: chipColor },
+}))
+
 const ExpectedValue = styled('span')(({ theme }) => ({
   color: theme.palette.success.main,
   fontWeight: theme.typography.h2.fontWeight,
@@ -71,8 +84,10 @@ const VarianceLabel = styled('span')(({ theme }) => ({
   marginRight: theme.spacing(1),
 }))
 
-const IssueAlertIcon = styled(ReportProblemOutlinedIcon)(({ theme }) => ({
-  color: theme.palette.error.main,
+const IssueAlertIcon = styled(ReportProblemOutlinedIcon, {
+  shouldForwardProp: prop => prop !== 'iconColor',
+})<{ iconColor: string }>(({ iconColor }) => ({
+  color: iconColor,
 }))
 
 const IssueAlertText = styled(Typography)(({ theme }) => ({
@@ -98,13 +113,33 @@ interface IssueRowProps {
   resultType?: 'payroll' | 'roster'
 }
 
+const severityConfig: Record<
+  IssueSeverity,
+  { label: string; colorToken: 'error' | 'warning' | 'info' }
+> = {
+  Critical: { label: 'Critical', colorToken: 'error' },
+  Error: { label: 'Error', colorToken: 'error' },
+  Warning: { label: 'Warning', colorToken: 'warning' },
+  Info: { label: 'Info', colorToken: 'info' },
+}
+
+const defaultSeverityStyle = severityConfig.Error
+
 export const IssueRow: React.FC<IssueRowProps> = ({
   issue,
   isSelected,
   onToggleSelection,
-  resultType = 'payroll',
+  resultType = 'roster',
 }) => {
   const varianceLabel = resultType === 'roster' ? 'Deviation' : 'Variance'
+  const severity = issue.severity ?? 'Error'
+  const severityStyle = severityConfig[severity] ?? defaultSeverityStyle
+  const accentColor =
+    severityStyle.colorToken === 'error'
+      ? '#dc2626'
+      : severityStyle.colorToken === 'warning'
+        ? '#d97706'
+        : '#2563eb'
 
   return (
     <IssueRowWrapper>
@@ -115,14 +150,20 @@ export const IssueRow: React.FC<IssueRowProps> = ({
           <EmployeeId variant="body2" color="text.disabled">
             ID: {issue.empId}
           </EmployeeId>
+          <SeverityChip
+            label={severityStyle.label}
+            size="small"
+            variant="outlined"
+            chipColor={accentColor}
+          />
         </HeaderRow>
         <IssueDetails variant="body2" color="text.primary">
           Actual: <strong>{issue.actualValue}</strong>, expected:{' '}
           <ExpectedValue>{issue.expectedValue}</ExpectedValue> — {issue.reason}
         </IssueDetails>
 
-        <IssueAlert>
-          <IssueAlertIcon />
+        <IssueAlert accentColor={accentColor}>
+          <IssueAlertIcon iconColor={accentColor} />
           <IssueAlertText variant="body2">
             <VarianceLabel>
               {varianceLabel}: {issue.variance}

--- a/frontend/src/shared/compliance-check/components/IssuesByCategory.tsx
+++ b/frontend/src/shared/compliance-check/components/IssuesByCategory.tsx
@@ -230,6 +230,7 @@ export const IssuesByCategory: React.FC<IssuesByCategoryProps> = ({
                       issue={issue}
                       isSelected={selectedIssueIds.includes(issue.id)}
                       onToggleSelection={() => toggleIssueSelection(issue.id)}
+                      resultType={resultType}
                     />
                   ))
                 ) : (

--- a/frontend/src/shared/compliance-check/index.ts
+++ b/frontend/src/shared/compliance-check/index.ts
@@ -33,6 +33,7 @@ export type {
   ValidationMetadata,
   IssueCategory,
   IssueItem,
+  IssueSeverity,
   UploadedFile,
   ValidationSummary,
   ComplianceConfig,

--- a/frontend/src/shared/compliance-check/types/complianceApiResponse.type.ts
+++ b/frontend/src/shared/compliance-check/types/complianceApiResponse.type.ts
@@ -29,6 +29,7 @@ export interface ComplianceApiResponse {
       id?: number
       name?: string
       emp_id?: string
+      severity?: 'Critical' | 'Error' | 'Warning' | 'Info'
       actual_value?: string
       expected_value?: string
       reason?: string

--- a/frontend/src/shared/compliance-check/types/complianceCheck.type.ts
+++ b/frontend/src/shared/compliance-check/types/complianceCheck.type.ts
@@ -17,10 +17,13 @@ export interface ValidationMetadata {
   validationId?: string
 }
 
+export type IssueSeverity = 'Critical' | 'Error' | 'Warning' | 'Info'
+
 export interface IssueItem {
   id: number
   name: string
   empId: string
+  severity?: IssueSeverity
   actualValue: string
   expectedValue: string
   reason: string

--- a/frontend/src/shared/compliance-check/utils/mapper.ts
+++ b/frontend/src/shared/compliance-check/utils/mapper.ts
@@ -46,6 +46,7 @@ export const mapBackendToComplianceResults = (
         id: issue.id ?? 0,
         name: issue.name ?? DEFAULT_TEXT,
         empId: issue.emp_id ?? DEFAULT_TEXT,
+        severity: issue.severity,
         actualValue: issue.actual_value ?? DEFAULT_VALUE,
         expectedValue: issue.expected_value ?? DEFAULT_VALUE,
         reason: issue.reason ?? '',


### PR DESCRIPTION
## Summary
- surface roster issue severity from the validation response into the shared compliance result model
- render severity-specific styling and chips in roster issue rows instead of treating every issue as an error
- count both Critical and Error issues in the roster summary and cover the mapping with tests

## Testing
- npx vitest run src/modules/roster/utils/mapValidationResponse.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issues now display severity levels with color-coded visual indicators, categorized as Critical, Error, Warning, or Info
  * Enhanced issue organization and visual differentiation by severity level

* **Bug Fixes**
  * Corrected critical issue count calculation to properly include both Error and Critical severity levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->