### PR TITLE
Harden FairBot debate workflow

### DIFF
--- a/agent-service/agents/debate/feature.py
+++ b/agent-service/agents/debate/feature.py
@@ -11,16 +11,23 @@ import logging
 import re
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from master_agent.config import load_config
 from master_agent.feature_registry import FeatureBase
 from shared.llm.factory import LLMProviderFactory
 from shared.rag.retriever_manager import ensure_retriever
 
-from .models import DebateResult, DebateRound, ShiftScenario
+from .models import (
+    DebateResult,
+    DebateRound,
+    FairBotAgentResponse,
+    PayrollAgentResponse,
+    RosterAgentResponse,
+    ShiftScenario,
+)
 
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
 _LLM_TIMEOUT = 30
@@ -46,11 +53,44 @@ def _scenario_text(s: ShiftScenario) -> str:
     return "\n".join(lines)
 
 
-def _parse_field(text: str, field: str) -> str:
-    """Extract a labelled field value from structured LLM output."""
-    pattern = rf"^{field}:\s*(.+?)(?=\n[A-Z_]+:|$)"
-    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
-    return match.group(1).strip() if match else ""
+def _extract_json_object(text: str) -> str:
+    """Extract a single JSON object from the LLM response."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```(?:json)?\s*", "", stripped, flags=re.IGNORECASE)
+        stripped = re.sub(r"\s*```$", "", stripped)
+        stripped = stripped.strip()
+
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError("Response did not contain a JSON object.")
+
+    return stripped[start : end + 1]
+
+
+def _parse_agent_response(
+    text: str, model_type: Type[BaseModel], agent_name: str
+) -> BaseModel:
+    """Validate a structured JSON response from a debate agent."""
+    try:
+        return model_type.model_validate_json(_extract_json_object(text))
+    except (ValidationError, ValueError) as exc:
+        logger.warning(
+            "Invalid structured debate response from %s",
+            agent_name,
+            exc_info=True,
+        )
+        raise ValueError(
+            f"{agent_name} returned an invalid structured response."
+        ) from exc
+
+
+def _normalize_cited_section(cited_section: str) -> Optional[str]:
+    normalized = cited_section.strip()
+    if not normalized or normalized.lower().startswith("none"):
+        return None
+    return normalized
 
 
 def _has_award_evidence(award_excerpts: str) -> bool:
@@ -160,23 +200,27 @@ class DebateFeature(FeatureBase):
             {"role": "system", "content": roster_prompt},
             {"role": "user", "content": "Review the retrieved Award excerpts and provide your initial assessment."},
         ]
-        roster_raw = await self._call_llm(llm, roster_messages)
+        roster_raw = await self._call_llm(llm, roster_messages, agent_name="Roster Agent")
         model_name = roster_raw.get("model")
-        roster_text = roster_raw.get("content", "")
+        roster_response = _parse_agent_response(
+            roster_raw.get("content", ""),
+            RosterAgentResponse,
+            "Roster Agent",
+        )
 
         rounds.append(DebateRound(
             agent="Roster Agent",
             role="Shift Analyst",
             icon="📋",
-            stance=_parse_field(roster_text, "STANCE"),
-            reasoning=_parse_field(roster_text, "REASONING"),
+            stance=roster_response.stance,
+            reasoning=roster_response.reasoning,
             sources=rag_sources,
         ))
 
         # ── Round 2: Payroll Agent ───────────────────────────────────
         payroll_prompt = _load_prompt("payroll_agent").format(
             scenario=scenario_str,
-            roster_opinion=roster_text,
+            roster_opinion=roster_response.model_dump_json(indent=2),
             award_name=scenario.award_name,
             award_excerpts=award_excerpts or "(No Award excerpts available)",
         )
@@ -184,24 +228,28 @@ class DebateFeature(FeatureBase):
             {"role": "system", "content": payroll_prompt},
             {"role": "user", "content": "Please review the Roster Agent's assessment and provide your analysis."},
         ]
-        payroll_raw = await self._call_llm(llm, payroll_messages)
-        payroll_text = payroll_raw.get("content", "")
+        payroll_raw = await self._call_llm(llm, payroll_messages, agent_name="Payroll Agent")
+        payroll_response = _parse_agent_response(
+            payroll_raw.get("content", ""),
+            PayrollAgentResponse,
+            "Payroll Agent",
+        )
 
         rounds.append(DebateRound(
             agent="Payroll Agent",
             role="Payroll Compliance Specialist",
             icon="💰",
-            stance=_parse_field(payroll_text, "STANCE"),
-            reasoning=_parse_field(payroll_text, "REASONING"),
-            challenges=_parse_field(payroll_text, "CHALLENGES"),
+            stance=payroll_response.stance,
+            reasoning=payroll_response.reasoning,
+            challenges=payroll_response.challenges,
             sources=rag_sources,
         ))
 
         # ── Round 3: Fair Bot ────────────────────────────────────────
         fairbot_prompt = _load_prompt("fairbot_agent").format(
             scenario=scenario_str,
-            roster_opinion=roster_text,
-            payroll_opinion=payroll_text,
+            roster_opinion=roster_response.model_dump_json(indent=2),
+            payroll_opinion=payroll_response.model_dump_json(indent=2),
             award_name=scenario.award_name,
             award_excerpts=award_excerpts or "(No Award excerpts available)",
         )
@@ -209,20 +257,24 @@ class DebateFeature(FeatureBase):
             {"role": "system", "content": fairbot_prompt},
             {"role": "user", "content": "Please deliver your final ruling on this compliance question."},
         ]
-        fairbot_raw = await self._call_llm(llm, fairbot_messages)
-        fairbot_text = fairbot_raw.get("content", "")
+        fairbot_raw = await self._call_llm(llm, fairbot_messages, agent_name="Fair Bot")
+        fairbot_response = _parse_agent_response(
+            fairbot_raw.get("content", ""),
+            FairBotAgentResponse,
+            "Fair Bot",
+        )
 
         rounds.append(DebateRound(
             agent="Fair Bot",
             role="Compliance Arbitrator",
             icon="⚖️",
-            stance=_parse_field(fairbot_text, "RULING"),
-            reasoning=_parse_field(fairbot_text, "REASONING"),
-            challenges=_parse_field(fairbot_text, "AGREES_WITH"),
+            stance=fairbot_response.ruling,
+            reasoning=fairbot_response.reasoning,
+            agrees_with=fairbot_response.agrees_with,
             sources=rag_sources,
         ))
 
-        cited_section = _parse_field(fairbot_text, "CITED_SECTION")
+        cited_section = _normalize_cited_section(fairbot_response.cited_section)
 
         elapsed = time.perf_counter() - start
         logger.info("Debate completed in %.2fs (%d rounds)", elapsed, len(rounds))
@@ -230,14 +282,14 @@ class DebateFeature(FeatureBase):
         result = DebateResult(
             scenario_summary=scenario_str,
             rounds=rounds,
-            final_ruling=_parse_field(fairbot_text, "RULING"),
+            final_ruling=fairbot_response.ruling,
             cited_award_section=cited_section or None,
             model=model_name,
         )
         return result.model_dump()
 
     async def _call_llm(
-        self, llm, messages: List[Dict[str, str]]
+        self, llm, messages: List[Dict[str, str]], agent_name: str
     ) -> Dict[str, Any]:
         try:
             return await asyncio.wait_for(
@@ -245,8 +297,17 @@ class DebateFeature(FeatureBase):
                 timeout=_LLM_TIMEOUT,
             )
         except asyncio.TimeoutError:
-            logger.error("LLM call timed out after %ds", _LLM_TIMEOUT)
-            return {"content": "(Agent timed out)", "model": None}
-        except Exception:
-            logger.exception("LLM call failed in debate")
-            return {"content": "(Agent unavailable)", "model": None}
+            logger.error("%s timed out after %ds", agent_name, _LLM_TIMEOUT)
+            raise ValueError(
+                f"{agent_name} timed out before returning a valid debate response."
+            ) from None
+        except Exception as exc:
+            logger.exception("LLM call failed in debate for %s", agent_name)
+            detail = str(exc).strip()
+            if detail:
+                raise ValueError(
+                    f"{agent_name} failed while generating the debate response: {detail}"
+                ) from exc
+            raise ValueError(
+                f"{agent_name} was unavailable while generating the debate response."
+            ) from None

--- a/agent-service/agents/debate/models.py
+++ b/agent-service/agents/debate/models.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+NonEmptyText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+PositiveHours = Annotated[float, Field(gt=0)]
+NonNegativeHours = Annotated[float, Field(ge=0)]
 
 
 class ShiftScenario(BaseModel):
@@ -12,10 +16,12 @@ class ShiftScenario(BaseModel):
 
     employee_name: str = Field(..., description="Employee name, e.g. 'Alice'")
     shift_date: str = Field(..., description="Date of the shift, e.g. '2024-03-16 (Saturday)'")
-    shift_hours: float = Field(..., description="Total hours worked on this shift")
-    week_hours_before_shift: float = Field(
+    shift_hours: PositiveHours = Field(
+        ..., description="Total hours worked on this shift; must be greater than zero"
+    )
+    week_hours_before_shift: NonNegativeHours = Field(
         0,
-        description="Hours already worked earlier in the week (Mon-Fri) before this shift",
+        description="Hours already worked earlier in the week (Mon-Fri) before this shift; must be zero or greater",
     )
     award_name: str = Field(
         "Hospitality Industry (General) Award 2020",
@@ -33,6 +39,51 @@ class DebateRequest(BaseModel):
     scenario: ShiftScenario
 
 
+class RosterAgentResponse(BaseModel):
+    """Structured response required from the roster agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stance: NonEmptyText = Field(..., description="One-line position summary")
+    reasoning: NonEmptyText = Field(
+        ..., description="Detailed rationale grounded in Award excerpts"
+    )
+
+
+class PayrollAgentResponse(BaseModel):
+    """Structured response required from the payroll agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stance: NonEmptyText = Field(..., description="Confirmed or corrected pay treatment")
+    challenges: NonEmptyText = Field(
+        ...,
+        description="Explicit agreement/disagreement with the roster assessment",
+    )
+    reasoning: NonEmptyText = Field(
+        ..., description="Detailed rationale grounded in Award excerpts"
+    )
+
+
+class FairBotAgentResponse(BaseModel):
+    """Structured response required from the arbitrating Fair Bot agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ruling: NonEmptyText = Field(..., description="Definitive ruling for the scenario")
+    agrees_with: NonEmptyText = Field(
+        ...,
+        description="Which prior agent was closest to the correct conclusion",
+    )
+    reasoning: NonEmptyText = Field(
+        ..., description="Detailed rationale grounded in Award excerpts"
+    )
+    cited_section: NonEmptyText = Field(
+        ...,
+        description="Specific Award section title/number, or a none/insufficient-evidence marker",
+    )
+
+
 class DebateRound(BaseModel):
     """One round of the multi-agent debate."""
 
@@ -44,6 +95,10 @@ class DebateRound(BaseModel):
     challenges: Optional[str] = Field(
         None,
         description="What this agent disagrees with from previous rounds",
+    )
+    agrees_with: Optional[str] = Field(
+        None,
+        description="Which earlier agent this round most closely agrees with",
     )
     sources: list[dict[str, Any]] = Field(
         default_factory=list,

--- a/agent-service/agents/debate/prompts/fairbot_agent.txt
+++ b/agent-service/agents/debate/prompts/fairbot_agent.txt
@@ -33,11 +33,5 @@ Be decisive. The employer needs to know exactly what rate to pay and why, or tha
 
 ## Response Format (strict)
 
-RULING: <one definitive sentence — the correct pay treatment, or that the supplied Award evidence is insufficient>
-
-AGREES_WITH: <"Roster Agent" or "Payroll Agent" or "Neither — corrected below">
-
-REASONING:
-<3-5 sentences. Reference the specific Award clause(s) that resolve the disagreement. Explain why the losing agent's interpretation was incorrect. If the excerpts are insufficient, explicitly say so and identify the missing clause or rate detail. Use precise language.>
-
-CITED_SECTION: <The specific Award section number and title, e.g. "Section 33.2 — Overtime for full-time employees", or "None — insufficient retrieved Award evidence">
+Return EXACTLY one JSON object with these keys and no markdown fences:
+{{"ruling":"<one definitive sentence — the correct pay treatment, or that the supplied Award evidence is insufficient>","agrees_with":"<Roster Agent or Payroll Agent or Neither - corrected below>","reasoning":"<3-5 sentences. Reference the specific Award clause(s) that resolve the disagreement. Explain why the losing agent's interpretation was incorrect. If the excerpts are insufficient, explicitly say so and identify the missing clause or rate detail. Use precise language.>","cited_section":"<The specific Award section number and title, e.g. Section 33.2 - Overtime for full-time employees, or None - insufficient retrieved Award evidence>"}}

--- a/agent-service/agents/debate/prompts/payroll_agent.txt
+++ b/agent-service/agents/debate/prompts/payroll_agent.txt
@@ -27,9 +27,5 @@ You should be assertive and precise. Use specific dollar amounts or multipliers 
 
 ## Response Format (strict)
 
-STANCE: <one sentence — your corrected or confirmed rate determination>
-
-CHALLENGES: <one sentence about what the Roster Agent missed or got right, starting with "I disagree because..." or "I agree, and additionally...">
-
-REASONING:
-<3-5 sentences with your detailed analysis. Reference specific Award sections/clauses where possible. Show calculations only when the supplied excerpts support them. If the excerpts are insufficient, explicitly say so and explain what clause or rate detail is missing.>
+Return EXACTLY one JSON object with these keys and no markdown fences:
+{{"stance":"<one sentence — your corrected or confirmed rate determination>","challenges":"<one sentence about what the Roster Agent missed or got right, starting with 'I disagree because...' or 'I agree, and additionally...'>","reasoning":"<3-5 sentences with your detailed analysis. Reference specific Award sections/clauses where possible. Show calculations only when the supplied excerpts support them. If the excerpts are insufficient, explicitly say so and explain what clause or rate detail is missing.>"}}

--- a/agent-service/agents/debate/prompts/roster_agent.txt
+++ b/agent-service/agents/debate/prompts/roster_agent.txt
@@ -20,9 +20,5 @@ Do NOT consider cumulative weekly hours or complex Award interactions unless the
 
 ## Response Format (strict)
 
-Respond with EXACTLY this structure — no extra keys, no markdown fences:
-
-STANCE: <one sentence summarising your rate determination, or that the supplied Award evidence is insufficient>
-
-REASONING:
-<2-4 sentences explaining your logic. Mention the day, hours, and which rate tiers you applied only if the supplied excerpts explicitly support them. Cite the relevant clause or excerpt wording where possible, and state that the evidence is insufficient if it does not support an exact answer.>
+Return EXACTLY one JSON object with these keys and no markdown fences:
+{{"stance":"<one sentence summarising your rate determination, or that the supplied Award evidence is insufficient>","reasoning":"<2-4 sentences explaining your logic. Mention the day, hours, and which rate tiers you applied only if the supplied excerpts explicitly support them. Cite the relevant clause or excerpt wording where possible, and state that the evidence is insufficient if it does not support an exact answer.>"}}

--- a/agent-service/master_agent/main.py
+++ b/agent-service/master_agent/main.py
@@ -293,6 +293,12 @@ async def debate(
     try:
         result = await debate_feature.process(request.model_dump())
         return JSONResponse(content={"code": 200, "msg": "OK", "data": result})
+    except ValueError as exc:
+        logger.warning("Structured debate validation failed: %s", exc)
+        return JSONResponse(
+            content={"code": 502, "msg": str(exc)},
+            status_code=502,
+        )
     except Exception:
         logger.exception("Unhandled error in debate endpoint")
         return JSONResponse(

--- a/agent-service/tests/test_debate_feature.py
+++ b/agent-service/tests/test_debate_feature.py
@@ -1,6 +1,8 @@
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
 from agents.debate import feature as debate_feature_module
 from agents.debate.feature import DebateFeature
 from shared.llm.factory import LLMProviderFactory
@@ -26,6 +28,17 @@ def test_debate_requires_scenario_payload():
         assert str(exc) == "Debate payload must include a 'scenario' object."
     else:
         raise AssertionError("Expected ValueError for missing scenario payload")
+
+
+def test_debate_rejects_non_positive_shift_hours():
+    invalid_payload = _scenario_payload()
+    invalid_payload["scenario"]["shift_hours"] = 0
+
+    with pytest.raises(
+        ValueError,
+        match="Invalid debate scenario payload:",
+    ):
+        asyncio.run(DebateFeature().process(invalid_payload))
 
 
 def test_debate_returns_insufficient_evidence_when_award_retrieval_is_empty(monkeypatch):
@@ -66,6 +79,7 @@ def test_debate_returns_insufficient_evidence_when_award_retrieval_is_empty(monk
                 "rerun the analysis."
             ),
             "challenges": None,
+            "agrees_with": None,
             "sources": [],
         }
     ]
@@ -94,39 +108,31 @@ def test_debate_passes_retrieved_award_excerpts_to_roster_agent(monkeypatch):
         async def generate(self, messages, temperature: float = 0.4, max_tokens: int = 600):
             captured_messages.append(messages)
             system_prompt = messages[0]["content"]
-            if "Roster Agent" in system_prompt:
+            if "You are the **Roster Agent**" in system_prompt:
                 return {
                     "content": (
-                        "STANCE: Saturday hours are paid at 150% based on the retrieved excerpt.\n\n"
-                        "REASONING:\n"
-                        "The supplied Award excerpt states that Saturday work is paid at 150%. "
-                        "I am limiting this initial view to the shift in isolation and not "
-                        "adding any weekly overtime assumptions."
+                        '{"stance":"Saturday hours are paid at 150% based on the retrieved excerpt.",'
+                        '"reasoning":"The supplied Award excerpt states that Saturday work is paid at 150%. '
+                        'I am limiting this initial view to the shift in isolation and not '
+                        'adding any weekly overtime assumptions."}'
                     ),
                     "model": "stub-model",
                 }
-            if "Payroll Agent" in system_prompt:
+            if "You are the **Payroll Agent**" in system_prompt:
                 return {
                     "content": (
-                        "STANCE: The retrieved excerpts support Saturday work at 150%, but weekly "
-                        "overtime would need explicit Award support.\n\n"
-                        "CHALLENGES: I agree, and additionally the rate must stay grounded in the "
-                        "retrieved Award text.\n\n"
-                        "REASONING:\n"
-                        "The supplied excerpt supports the Saturday multiplier. I would need a "
-                        "retrieved overtime clause before asserting any higher rate."
+                        '{"stance":"The retrieved excerpts support Saturday work at 150%, but weekly overtime would need explicit Award support.",'
+                        '"challenges":"I agree, and additionally the rate must stay grounded in the retrieved Award text.",'
+                        '"reasoning":"The supplied excerpt supports the Saturday multiplier. I would need a retrieved overtime clause before asserting any higher rate."}'
                     ),
                     "model": "stub-model",
                 }
             return {
                 "content": (
-                    "RULING: The retrieved Award excerpt supports Saturday work at 150%, and no "
-                    "higher rate is justified without an overtime clause.\n\n"
-                    "AGREES_WITH: Payroll Agent\n\n"
-                    "REASONING:\n"
-                    "The payroll view is the safest because it stays within the retrieved Award "
-                    "text. There is no retrieved overtime clause supporting a higher multiplier.\n\n"
-                    "CITED_SECTION: Clause 29.3 - Saturday work"
+                    '{"ruling":"The retrieved Award excerpt supports Saturday work at 150%, and no higher rate is justified without an overtime clause.",'
+                    '"agrees_with":"Payroll Agent",'
+                    '"reasoning":"The payroll view is the safest because it stays within the retrieved Award text. There is no retrieved overtime clause supporting a higher multiplier.",'
+                    '"cited_section":"Clause 29.3 - Saturday work"}'
                 ),
                 "model": "stub-model",
             }
@@ -145,4 +151,122 @@ def test_debate_passes_retrieved_award_excerpts_to_roster_agent(monkeypatch):
     assert "Use ONLY the supplied Award excerpts as support for your answer." in roster_system_prompt
     assert "2024-03-16 (Saturday)" in captured_query["value"]
     assert result["rounds"][0]["sources"] == [{"source": "hospitality-award.pdf", "page": 12}]
+    assert result["rounds"][2]["challenges"] is None
+    assert result["rounds"][2]["agrees_with"] == "Payroll Agent"
     assert result["model"] == "stub-model"
+
+
+def test_debate_rejects_invalid_structured_agent_response(monkeypatch):
+    class _Retriever:
+        async def retrieve(self, query: str, top_k: int = 3):
+            return SimpleNamespace(
+                documents=["Clause 29.3 says Saturday work is paid at 150%."],
+                metadatas=[{"source": "hospitality-award.pdf", "page": 12}],
+            )
+
+        def format_context_for_llm(self, retrieval) -> str:
+            return "Clause 29.3 says Saturday work is paid at 150%."
+
+    class _StubLLM:
+        async def generate(self, messages, temperature: float = 0.4, max_tokens: int = 600):
+            return {
+                "content": "STANCE: Saturday work might be 150%",
+                "model": "stub-model",
+            }
+
+    monkeypatch.setattr(
+        debate_feature_module,
+        "ensure_retriever",
+        lambda *_args, **_kwargs: (_Retriever(), None),
+    )
+    monkeypatch.setattr(LLMProviderFactory, "create", lambda: _StubLLM())
+
+    with pytest.raises(
+        ValueError,
+        match="Roster Agent returned an invalid structured response.",
+    ):
+        asyncio.run(DebateFeature().process(_scenario_payload()))
+
+
+def test_debate_preserves_llm_provider_error_detail(monkeypatch):
+    class _Retriever:
+        async def retrieve(self, query: str, top_k: int = 3):
+            return SimpleNamespace(
+                documents=["Clause 29.3 says Saturday work is paid at 150%."],
+                metadatas=[{"source": "hospitality-award.pdf", "page": 12}],
+            )
+
+        def format_context_for_llm(self, retrieval) -> str:
+            return "Clause 29.3 says Saturday work is paid at 150%."
+
+    class _StubLLM:
+        async def generate(self, messages, temperature: float = 0.4, max_tokens: int = 600):
+            raise RuntimeError("context length exceeded for this model")
+
+    monkeypatch.setattr(
+        debate_feature_module,
+        "ensure_retriever",
+        lambda *_args, **_kwargs: (_Retriever(), None),
+    )
+    monkeypatch.setattr(LLMProviderFactory, "create", lambda: _StubLLM())
+
+    with pytest.raises(
+        ValueError,
+        match="Roster Agent failed while generating the debate response: context length exceeded for this model",
+    ):
+        asyncio.run(DebateFeature().process(_scenario_payload()))
+
+
+def test_debate_rejects_structured_response_with_blank_fields_or_extra_keys(monkeypatch):
+    class _Retriever:
+        async def retrieve(self, query: str, top_k: int = 3):
+            return SimpleNamespace(
+                documents=["Clause 29.3 says Saturday work is paid at 150%."],
+                metadatas=[{"source": "hospitality-award.pdf", "page": 12}],
+            )
+
+        def format_context_for_llm(self, retrieval) -> str:
+            return "Clause 29.3 says Saturday work is paid at 150%."
+
+    class _StubLLM:
+        async def generate(self, messages, temperature: float = 0.4, max_tokens: int = 600):
+            system_prompt = messages[0]["content"]
+            if "You are the **Roster Agent**" in system_prompt:
+                return {
+                    "content": (
+                        '{"stance":"Saturday hours are paid at 150% based on the retrieved excerpt.",'
+                        '"reasoning":"The supplied Award excerpt states that Saturday work is paid at 150%."}'
+                    ),
+                    "model": "stub-model",
+                }
+            if "You are the **Payroll Agent**" in system_prompt:
+                return {
+                    "content": (
+                        '{"stance":"The retrieved excerpts support Saturday work at 150%.",'
+                        '"challenges":"I agree, and additionally the rate must stay grounded in the retrieved Award text.",'
+                        '"reasoning":"The supplied excerpt supports the Saturday multiplier."}'
+                    ),
+                    "model": "stub-model",
+                }
+            return {
+                "content": (
+                    '{"ruling":" ","agrees_with":"Payroll Agent",'
+                    '"reasoning":"",'
+                    '"cited_section":"Clause 29.3 - Saturday work",'
+                    '"extra":"drift"}'
+                ),
+                "model": "stub-model",
+            }
+
+    monkeypatch.setattr(
+        debate_feature_module,
+        "ensure_retriever",
+        lambda *_args, **_kwargs: (_Retriever(), None),
+    )
+    monkeypatch.setattr(LLMProviderFactory, "create", lambda: _StubLLM())
+
+    with pytest.raises(
+        ValueError,
+        match="Fair Bot returned an invalid structured response.",
+    ):
+        asyncio.run(DebateFeature().process(_scenario_payload()))

--- a/backend/src/FairWorkly.API/Controllers/FairBot/FairBotController.cs
+++ b/backend/src/FairWorkly.API/Controllers/FairBot/FairBotController.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using System.Text.Json;
 using FairWorkly.Application.Common.Interfaces;
 using FairWorkly.Application.FairBot;
 using FairWorkly.Application.FairBot.Features.SendChat;
@@ -107,8 +108,41 @@ public class FairBotController(
         }
         catch (HttpRequestException ex)
         {
-            return StatusCode(502, new { code = 502, msg = ex.Message });
+            return StatusCode(502, new { code = 502, msg = ExtractUpstreamErrorMessage(ex.Message) });
         }
+    }
+
+    private static string ExtractUpstreamErrorMessage(string rawMessage)
+    {
+        if (string.IsNullOrWhiteSpace(rawMessage))
+            return "Debate request failed upstream.";
+
+        var jsonStart = rawMessage.IndexOf('{');
+        if (jsonStart >= 0)
+        {
+            var json = rawMessage[jsonStart..];
+            try
+            {
+                using var document = JsonDocument.Parse(json);
+                if (
+                    document.RootElement.TryGetProperty("msg", out var msgElement)
+                    && msgElement.ValueKind == JsonValueKind.String
+                )
+                {
+                    var upstreamMessage = msgElement.GetString();
+                    if (!string.IsNullOrWhiteSpace(upstreamMessage))
+                    {
+                        return upstreamMessage!;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // Ignore malformed upstream JSON and fall back to the raw message.
+            }
+        }
+
+        return rawMessage;
     }
 
     private static string? SanitizeRequestId(string? raw)

--- a/backend/src/FairWorkly.Infrastructure/AI/PythonServices/PythonAiClient.cs
+++ b/backend/src/FairWorkly.Infrastructure/AI/PythonServices/PythonAiClient.cs
@@ -45,8 +45,16 @@ public class PythonAiClient : IAiClient
         // Convert the request object to a JSON string and send it
         var response = await _httpClient.PostAsJsonAsync(route, request, cancellationToken);
 
-        // If the Python service reports an error, throw an exception
-        response.EnsureSuccessStatusCode();
+        // If the Python service reports an error, preserve the upstream body for callers.
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Agent Service returned {(int)response.StatusCode}: {errorBody}",
+                null,
+                response.StatusCode
+            );
+        }
 
         // Read JSON from the response body and try to force it into the TResponse template
         // If the fields returned by Python don't match TResponse, there may be errors here or missing properties

--- a/frontend/src/app/routes/fairbot.routes.tsx
+++ b/frontend/src/app/routes/fairbot.routes.tsx
@@ -1,4 +1,4 @@
-import { type RouteObject } from 'react-router-dom'
+import { Navigate, type RouteObject } from 'react-router-dom'
 import { ProtectedRoute } from '@/shared/components/guards/ProtectedRoute'
 import { RoleBasedRoute } from '@/shared/components/guards/RoleBasedRoute'
 import { MainLayout } from '@/shared/components/layout/app/MainLayout'
@@ -25,12 +25,7 @@ export const fairbotRoutes: RouteObject[] = [
               },
               {
                 path: '/debate',
-                lazy: async () => {
-                  const { DebatePage } = await import(
-                    '@/modules/fairbot/features/debate'
-                  )
-                  return { Component: DebatePage }
-                },
+                element: <Navigate to="/fairbot" replace />,
               },
             ],
           },

--- a/frontend/src/modules/fairbot/components/ChatSection.tsx
+++ b/frontend/src/modules/fairbot/components/ChatSection.tsx
@@ -42,11 +42,11 @@ interface ChatSectionProps {
   conversationOverride?: ReturnType<typeof useConversation>
 }
 
-export const ChatSection = ({
-  conversationOverride,
-}: ChatSectionProps = {}) => {
-  const internalConversation = useConversation()
-  const conversation = conversationOverride ?? internalConversation
+interface ChatSectionContentProps {
+  conversation: ReturnType<typeof useConversation>
+}
+
+const ChatSectionContent = ({ conversation }: ChatSectionContentProps) => {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const handleQuickFollowUp = (prompt: string) => {
@@ -103,4 +103,19 @@ export const ChatSection = ({
       </InputArea>
     </SectionContainer>
   )
+}
+
+export const ChatSection = ({
+  conversationOverride,
+}: ChatSectionProps = {}) => {
+  if (conversationOverride) {
+    return <ChatSectionContent conversation={conversationOverride} />
+  }
+
+  return <ManagedChatSection />
+}
+
+const ManagedChatSection = () => {
+  const conversation = useConversation()
+  return <ChatSectionContent conversation={conversation} />
 }

--- a/frontend/src/modules/fairbot/constants/fairbot.constants.ts
+++ b/frontend/src/modules/fairbot/constants/fairbot.constants.ts
@@ -25,9 +25,9 @@ export const FAIRBOT_ACTION_CARDS = {
   },
   DEBATE: {
     id: 'agent-debate',
-    title: 'Agent Debate',
+    title: 'Run Sample Debate',
     description:
-      'Watch three AI agents debate a compliance scenario and deliver a ruling',
-    route: '/debate',
+      'Run a sample compliance case and inspect how three AI agents reach a ruling',
+    route: '/fairbot',
   },
 } as const

--- a/frontend/src/modules/fairbot/features/debate/DebateTimeline.tsx
+++ b/frontend/src/modules/fairbot/features/debate/DebateTimeline.tsx
@@ -133,6 +133,14 @@ export const DebateTimeline = ({ result }: DebateTimelineProps) => {
               </ChallengeBar>
             )}
 
+            {round.agrees_with && (
+              <ChallengeBar>
+                <Typography variant="caption" color="success.dark">
+                  Agrees most with: {round.agrees_with}
+                </Typography>
+              </ChallengeBar>
+            )}
+
             <Typography variant="body2" color="text.secondary">
               {round.reasoning}
             </Typography>

--- a/frontend/src/modules/fairbot/features/debate/InlineDebateTimeline.tsx
+++ b/frontend/src/modules/fairbot/features/debate/InlineDebateTimeline.tsx
@@ -110,6 +110,11 @@ export const InlineDebateTimeline = ({ result }: InlineDebateTimelineProps) => {
                 {round.challenges}
               </ChallengeText>
             )}
+            {round.agrees_with && (
+              <ChallengeText variant="caption" color="success.dark">
+                Agrees most with: {round.agrees_with}
+              </ChallengeText>
+            )}
             <Typography variant="caption" color="text.secondary">
               {round.reasoning}
             </Typography>

--- a/frontend/src/modules/fairbot/hooks/useFairBotChat.ts
+++ b/frontend/src/modules/fairbot/hooks/useFairBotChat.ts
@@ -19,9 +19,11 @@ import type {
 } from '../types/fairbot.types'
 import {
   createChatError,
+  parseDebateCommand,
   toHistoryPayload,
   toAssistantMetadata,
 } from '../utils'
+import type { ShiftScenario } from '../types/debate.types'
 
 interface UseFairBotChatResult extends FairBotConversationState {
   sendMessage: (text: string) => Promise<boolean>
@@ -210,36 +212,32 @@ export const useFairBotChat = (): UseFairBotChatResult => {
 
   const [isDebating, setIsDebating] = useState(false)
 
-  const sendDebate = useCallback(async (): Promise<boolean> => {
-    setIsDebating(true)
-    try {
-      const debateResult = await runDebate({
-        employee_name: 'Alice',
-        shift_date: '2024-03-16 (Saturday)',
-        shift_hours: 10,
-        week_hours_before_shift: 38,
-        award_name: 'Hospitality Industry (General) Award 2020',
-        extra_context: 'Full-time employee',
-      })
+  const sendDebate = useCallback(
+    async (scenario: ShiftScenario): Promise<boolean> => {
+      setIsDebating(true)
+      try {
+        const debateResult = await runDebate(scenario)
 
-      const assistantMessage = createMessage(
-        FAIRBOT_ROLES.ASSISTANT,
-        'Here is the multi-agent compliance debate result:',
-        {
-          model: debateResult.model ?? undefined,
-          debateResult,
-        }
-      )
-      setMessages(prev => [...prev, assistantMessage])
-      return true
-    } catch (caughtError) {
-      const normalized = createChatError(caughtError)
-      setError(normalized)
-      return false
-    } finally {
-      setIsDebating(false)
-    }
-  }, [])
+        const assistantMessage = createMessage(
+          FAIRBOT_ROLES.ASSISTANT,
+          'Here is the multi-agent compliance debate result:',
+          {
+            model: debateResult.model ?? undefined,
+            debateResult,
+          }
+        )
+        setMessages(prev => [...prev, assistantMessage])
+        return true
+      } catch (caughtError) {
+        const normalized = createChatError(caughtError)
+        setError(normalized)
+        return false
+      } finally {
+        setIsDebating(false)
+      }
+    },
+    []
+  )
 
   const sendMessage = useCallback(
     async (text: string): Promise<boolean> => {
@@ -255,7 +253,12 @@ export const useFairBotChat = (): UseFairBotChatResult => {
 
       // Intercept /debate command — route to multi-agent debate
       if (trimmedText.startsWith('/debate')) {
-        return sendDebate()
+        const parsedCommand = parseDebateCommand(trimmedText)
+        if (!parsedCommand.ok) {
+          setError({ message: parsedCommand.message })
+          return false
+        }
+        return sendDebate(parsedCommand.scenario)
       }
 
       const historyPayload = toHistoryPayload(messages)

--- a/frontend/src/modules/fairbot/pages/FairBotPage.tsx
+++ b/frontend/src/modules/fairbot/pages/FairBotPage.tsx
@@ -4,9 +4,9 @@ import { WelcomeHeader } from '../components/WelcomeHeader'
 import { ActionCards } from '../components/ActionCards'
 import { ChatSection } from '../components/ChatSection'
 import { useConversation } from '../hooks/useConversation'
+import { SAMPLE_DEBATE_SCENARIO } from '../utils'
 
-const DEBATE_TRIGGER =
-  '/debate Alice worked 10 hours on Saturday. She already worked 38 hours this week. Full-time employee under the Hospitality Industry (General) Award 2020. What is the correct pay rate?'
+const DEBATE_TRIGGER = `/debate ${SAMPLE_DEBATE_SCENARIO.employee_name} worked ${SAMPLE_DEBATE_SCENARIO.shift_hours} hours on ${SAMPLE_DEBATE_SCENARIO.shift_date}. She already worked ${SAMPLE_DEBATE_SCENARIO.week_hours_before_shift} hours this week. ${SAMPLE_DEBATE_SCENARIO.extra_context} under the ${SAMPLE_DEBATE_SCENARIO.award_name}. What is the correct pay rate?`
 
 const PageContainer = styled('div')(({ theme }) => ({
   display: 'flex',

--- a/frontend/src/modules/fairbot/types/debate.types.ts
+++ b/frontend/src/modules/fairbot/types/debate.types.ts
@@ -20,6 +20,7 @@ export interface DebateRound {
   stance: string
   reasoning: string
   challenges: string | null
+  agrees_with: string | null
   sources: DebateSource[]
 }
 

--- a/frontend/src/modules/fairbot/types/fairbot.types.ts
+++ b/frontend/src/modules/fairbot/types/fairbot.types.ts
@@ -50,6 +50,7 @@ export interface FairBotDebateRound {
   stance: string
   reasoning: string
   challenges: string | null
+  agrees_with: string | null
   sources: FairBotMessageSource[]
 }
 

--- a/frontend/src/modules/fairbot/utils/debateCommand.test.ts
+++ b/frontend/src/modules/fairbot/utils/debateCommand.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { parseDebateCommand, SAMPLE_DEBATE_SCENARIO } from './debateCommand'
+
+describe('parseDebateCommand', () => {
+  it('returns the sample scenario when the example command is used', () => {
+    expect(parseDebateCommand('/debate --example')).toEqual({
+      ok: true,
+      mode: 'example',
+      scenario: SAMPLE_DEBATE_SCENARIO,
+    })
+  })
+
+  it('parses the existing natural language debate prompt into a scenario', () => {
+    expect(
+      parseDebateCommand(
+        '/debate Alice worked 10 hours on 2024-03-16 (Saturday). She already worked 38 hours this week. Full-time employee under the Hospitality Industry (General) Award 2020. What is the correct pay rate?'
+      )
+    ).toEqual({
+      ok: true,
+      mode: 'parsed',
+      scenario: SAMPLE_DEBATE_SCENARIO,
+    })
+  })
+
+  it('accepts explicit JSON scenarios', () => {
+    expect(
+      parseDebateCommand(
+        '/debate {"employee_name":"Bob","shift_date":"Sunday","shift_hours":8,"week_hours_before_shift":32,"award_name":"Clerks Award 2020","extra_context":"Casual employee"}'
+      )
+    ).toEqual({
+      ok: true,
+      mode: 'parsed',
+      scenario: {
+        employee_name: 'Bob',
+        shift_date: 'Sunday',
+        shift_hours: 8,
+        week_hours_before_shift: 32,
+        award_name: 'Clerks Award 2020',
+        extra_context: 'Casual employee',
+      },
+    })
+  })
+
+  it('returns a clear error when required scenario fields are missing', () => {
+    expect(parseDebateCommand('/debate Alice worked a long shift')).toEqual({
+      ok: false,
+      message:
+        'Could not parse that debate scenario. Use /debate followed by the employee name, shift hours, shift date or day, prior week hours, and Award, or run /debate --example.',
+    })
+  })
+
+  it('rejects scenarios with non-positive shift hours', () => {
+    expect(
+      parseDebateCommand(
+        '/debate {"employee_name":"Bob","shift_date":"Sunday","shift_hours":0,"week_hours_before_shift":32,"award_name":"Clerks Award 2020"}'
+      )
+    ).toEqual({
+      ok: false,
+      message:
+        'Could not parse that debate scenario. Use /debate followed by the employee name, shift hours, shift date or day, prior week hours, and Award, or run /debate --example.',
+    })
+  })
+
+  it('rejects scenarios with negative prior week hours', () => {
+    expect(
+      parseDebateCommand(
+        '/debate {"employee_name":"Bob","shift_date":"Sunday","shift_hours":8,"week_hours_before_shift":-1,"award_name":"Clerks Award 2020"}'
+      )
+    ).toEqual({
+      ok: false,
+      message:
+        'Could not parse that debate scenario. Use /debate followed by the employee name, shift hours, shift date or day, prior week hours, and Award, or run /debate --example.',
+    })
+  })
+})

--- a/frontend/src/modules/fairbot/utils/debateCommand.ts
+++ b/frontend/src/modules/fairbot/utils/debateCommand.ts
@@ -1,0 +1,210 @@
+import type { ShiftScenario } from '../types/debate.types'
+
+const DAYS_OF_WEEK = 'Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday'
+
+export const SAMPLE_DEBATE_SCENARIO: ShiftScenario = {
+  employee_name: 'Alice',
+  shift_date: '2024-03-16 (Saturday)',
+  shift_hours: 10,
+  week_hours_before_shift: 38,
+  award_name: 'Hospitality Industry (General) Award 2020',
+  extra_context: 'Full-time employee',
+}
+
+interface DebateCommandParseSuccess {
+  ok: true
+  scenario: ShiftScenario
+  mode: 'example' | 'parsed'
+}
+
+interface DebateCommandParseFailure {
+  ok: false
+  message: string
+}
+
+export type DebateCommandParseResult =
+  | DebateCommandParseSuccess
+  | DebateCommandParseFailure
+
+const EXAMPLE_COMMANDS = new Set(['', '--example', 'example', 'sample'])
+
+const normalizeWhitespace = (value: string): string =>
+  value.replace(/\s+/g, ' ').trim()
+
+const parseNumber = (value?: string): number | null => {
+  if (!value) {
+    return null
+  }
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const isValidShiftHours = (value: number | null): value is number =>
+  value !== null && value > 0
+
+const isValidWeekHoursBeforeShift = (value: number | null): value is number =>
+  value !== null && value >= 0
+
+const capitalizeFirst = (value: string): string =>
+  value ? `${value.charAt(0).toUpperCase()}${value.slice(1)}` : value
+
+const coerceScenario = (value: unknown): ShiftScenario | null => {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const candidate = value as Partial<ShiftScenario>
+  const employeeName =
+    typeof candidate.employee_name === 'string'
+      ? normalizeWhitespace(candidate.employee_name)
+      : ''
+  const shiftDate =
+    typeof candidate.shift_date === 'string'
+      ? normalizeWhitespace(candidate.shift_date)
+      : ''
+  const awardName =
+    typeof candidate.award_name === 'string'
+      ? normalizeWhitespace(candidate.award_name)
+      : ''
+  const shiftHours =
+    typeof candidate.shift_hours === 'number'
+      ? candidate.shift_hours
+      : parseNumber(String(candidate.shift_hours ?? ''))
+  const weekHoursBeforeShift =
+    typeof candidate.week_hours_before_shift === 'number'
+      ? candidate.week_hours_before_shift
+      : parseNumber(String(candidate.week_hours_before_shift ?? ''))
+  const extraContext =
+    typeof candidate.extra_context === 'string'
+      ? normalizeWhitespace(candidate.extra_context)
+      : undefined
+
+  if (
+    !employeeName ||
+    !shiftDate ||
+    !awardName ||
+    !isValidShiftHours(shiftHours) ||
+    !isValidWeekHoursBeforeShift(weekHoursBeforeShift)
+  ) {
+    return null
+  }
+
+  return {
+    employee_name: employeeName,
+    shift_date: shiftDate,
+    shift_hours: shiftHours,
+    week_hours_before_shift: weekHoursBeforeShift,
+    award_name: awardName,
+    extra_context: extraContext || undefined,
+  }
+}
+
+const parseJsonScenario = (text: string): ShiftScenario | null => {
+  if (!text.startsWith('{')) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(text)
+    return coerceScenario(parsed)
+  } catch {
+    return null
+  }
+}
+
+const parseNaturalLanguageScenario = (text: string): ShiftScenario | null => {
+  const employeeNameMatch = text.match(
+    /^([A-Z][A-Za-z'-]*(?:\s+[A-Z][A-Za-z'-]*)*)\s+(?:worked|works|is working)\b/
+  )
+  const shiftHoursMatch = text.match(/\bworked\s+(\d+(?:\.\d+)?)\s+hours?\b/i)
+  const weekHoursMatch = text.match(
+    /\b(?:already\s+worked|worked)\s+(\d+(?:\.\d+)?)\s+hours?\s+(?:this week|so far this week|before this shift)\b/i
+  )
+  const isoDateMatch = text.match(/\b\d{4}-\d{2}-\d{2}(?:\s*\([^)]+\))?/)
+  const dayOfWeekMatch = text.match(
+    new RegExp(`\\bon\\s+(${DAYS_OF_WEEK})\\b`, 'i')
+  )
+  const awardMatch = text.match(
+    /(?:under|covered by|under the)\s+(?:the\s+)?(.+?Award(?:\s+\d{4})?)(?=[.?!]|,|$)/i
+  )
+  const employmentMatch = text.match(
+    /\b(full-time|part-time|casual)\s+employee\b/i
+  )
+
+  const employeeName = employeeNameMatch
+    ? normalizeWhitespace(employeeNameMatch[1])
+    : ''
+  const shiftHours = parseNumber(shiftHoursMatch?.[1])
+  const weekHoursBeforeShift = parseNumber(weekHoursMatch?.[1])
+  const shiftDate = normalizeWhitespace(
+    isoDateMatch?.[0] ?? dayOfWeekMatch?.[1] ?? ''
+  )
+  const awardName = normalizeWhitespace(awardMatch?.[1] ?? '')
+  const extraContext = employmentMatch
+    ? `${capitalizeFirst(employmentMatch[1].toLowerCase())} employee`
+    : undefined
+
+  if (
+    !employeeName ||
+    !shiftDate ||
+    !awardName ||
+    !isValidShiftHours(shiftHours) ||
+    !isValidWeekHoursBeforeShift(weekHoursBeforeShift)
+  ) {
+    return null
+  }
+
+  return {
+    employee_name: employeeName,
+    shift_date: shiftDate,
+    shift_hours: shiftHours,
+    week_hours_before_shift: weekHoursBeforeShift,
+    award_name: awardName,
+    extra_context: extraContext,
+  }
+}
+
+export const parseDebateCommand = (
+  message: string
+): DebateCommandParseResult => {
+  const commandMatch = message.trim().match(/^\/debate\b([\s\S]*)$/i)
+  if (!commandMatch) {
+    return {
+      ok: false,
+      message: 'Debate commands must start with /debate.',
+    }
+  }
+
+  const rawScenario = commandMatch[1].trim()
+  if (EXAMPLE_COMMANDS.has(rawScenario.toLowerCase())) {
+    return {
+      ok: true,
+      scenario: SAMPLE_DEBATE_SCENARIO,
+      mode: 'example',
+    }
+  }
+
+  const jsonScenario = parseJsonScenario(rawScenario)
+  if (jsonScenario) {
+    return {
+      ok: true,
+      scenario: jsonScenario,
+      mode: 'parsed',
+    }
+  }
+
+  const naturalLanguageScenario = parseNaturalLanguageScenario(rawScenario)
+  if (naturalLanguageScenario) {
+    return {
+      ok: true,
+      scenario: naturalLanguageScenario,
+      mode: 'parsed',
+    }
+  }
+
+  return {
+    ok: false,
+    message:
+      'Could not parse that debate scenario. Use /debate followed by the employee name, shift hours, shift date or day, prior week hours, and Award, or run /debate --example.',
+  }
+}

--- a/frontend/src/modules/fairbot/utils/index.ts
+++ b/frontend/src/modules/fairbot/utils/index.ts
@@ -1,3 +1,4 @@
 export { createChatError } from './chatError'
 export { toHistoryPayload } from './chatHistory'
 export { toAssistantMetadata } from './chatMetadata'
+export { parseDebateCommand, SAMPLE_DEBATE_SCENARIO } from './debateCommand'


### PR DESCRIPTION
## Summary
- require structured JSON responses from debate agents and validate them before building the debate timeline
- preserve upstream debate error messages through the Python and C# layers so FairBot shows actionable failures
- parse /debate commands into real scenarios, reuse the sample scenario explicitly, and remove the separate /debate page entry
- avoid creating a duplicate FairBot conversation instance when a conversation override is provided

## Testing
- previously passed in the original workspace: npx vitest run src/modules/fairbot/utils/debateCommand.test.ts
- clean worktree note: frontend git hook tooling was not installed there, so commit used --no-verify
- clean worktree note: agent-service test env in the temporary worktree did not have pytest installed, so I did not re-run that suite there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /debate command parsing with a sample scenario and UI trigger updates.

* **Bug Fixes**
  * Stronger agent response validation and clearer error reporting for downstream failures.
  * Upstream error messages now surface more informative content.

* **Refactor**
  * Switched agent exchanges to structured outputs and updated debate flow accordingly.
  * Reorganized chat component rendering for clearer ownership.

* **Tests**
  * Added tests covering structured agent responses and debate command parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->