### PR TITLE
Lazy load frontend routes and xlsx export

### DIFF
--- a/frontend/src/app/routes/error.routes.tsx
+++ b/frontend/src/app/routes/error.routes.tsx
@@ -1,14 +1,18 @@
 import { type RouteObject } from 'react-router-dom'
-import NotFoundPage from '@/modules/error/pages/NotFoundPage'
-import { ForbiddenPage } from '@/modules/error/pages/ForbiddenPage'
 
 export const errorRoutes: RouteObject[] = [
   {
     path: '/403',
-    element: <ForbiddenPage />,
+    lazy: async () => {
+      const { ForbiddenPage } = await import('@/modules/error/pages/ForbiddenPage')
+      return { Component: ForbiddenPage }
+    },
   },
   {
     path: '*',
-    element: <NotFoundPage />,
+    lazy: async () => {
+      const module = await import('@/modules/error/pages/NotFoundPage')
+      return { Component: module.default }
+    },
   },
 ]

--- a/frontend/src/app/routes/public.routes.tsx
+++ b/frontend/src/app/routes/public.routes.tsx
@@ -2,10 +2,6 @@ import { type RouteObject } from 'react-router-dom'
 import { PublicMarketingLayout } from '@/shared/components/layout/public/PublicMarketingLayout'
 import { PublicAuthLayout } from '@/shared/components/layout/public/PublicAuthLayout'
 import { AuthBranding } from '@/modules/auth'
-import { HomePage } from '@/modules/home/pages/HomePage'
-import { LoginPage } from '@/modules/auth/pages/LoginPage'
-import { AcceptInvitePage } from '@/modules/auth/pages/AcceptInvitePage'
-import { ResetPasswordPage } from '@/modules/auth/pages/ResetPasswordPage'
 
 export const publicRoutes: RouteObject[] = [
   // Marketing pages (full-width center layout)
@@ -14,7 +10,10 @@ export const publicRoutes: RouteObject[] = [
     children: [
       {
         path: '/',
-        element: <HomePage />,
+        lazy: async () => {
+          const { HomePage } = await import('@/modules/home/pages/HomePage')
+          return { Component: HomePage }
+        },
       },
     ],
   },
@@ -24,15 +23,28 @@ export const publicRoutes: RouteObject[] = [
     children: [
       {
         path: '/login',
-        element: <LoginPage />,
+        lazy: async () => {
+          const { LoginPage } = await import('@/modules/auth/pages/LoginPage')
+          return { Component: LoginPage }
+        },
       },
       {
         path: '/accept-invite',
-        element: <AcceptInvitePage />,
+        lazy: async () => {
+          const { AcceptInvitePage } = await import(
+            '@/modules/auth/pages/AcceptInvitePage'
+          )
+          return { Component: AcceptInvitePage }
+        },
       },
       {
         path: '/reset-password',
-        element: <ResetPasswordPage />,
+        lazy: async () => {
+          const { ResetPasswordPage } = await import(
+            '@/modules/auth/pages/ResetPasswordPage'
+          )
+          return { Component: ResetPasswordPage }
+        },
       },
     ],
   },

--- a/frontend/src/app/routes/tools.routes.tsx
+++ b/frontend/src/app/routes/tools.routes.tsx
@@ -1,23 +1,6 @@
 import { Navigate, type RouteObject } from 'react-router-dom'
 import { MainLayout } from '@/shared/components/layout/app/MainLayout'
 import { ProtectedRoute } from '@/shared/components/guards/ProtectedRoute'
-
-// Payroll pages
-import { PayrollUpload } from '@/modules/payroll/pages/PayrollUpload'
-import { PayrollResults } from '@/modules/payroll/pages/PayrollResults'
-
-// Compliance pages
-import { RosterUpload } from '@/modules/roster/pages/RosterUpload'
-import { RosterResults } from '@/modules/roster/pages/RosterResults'
-
-// Documents pages
-import { DocumentTemplates } from '@/modules/documents/pages/DocumentTemplates'
-import { GenerateDocument } from '@/modules/documents/pages/GenerateDocument'
-import { DocumentLibrary } from '@/modules/documents/pages/DocumentLibrary'
-
-// Settings pages
-import { Settings } from '@/modules/settings/pages/Settings'
-
 import { RoleBasedRoute } from '@/shared/components/guards/RoleBasedRoute'
 
 export const toolRoutes: RouteObject[] = [
@@ -34,8 +17,24 @@ export const toolRoutes: RouteObject[] = [
               {
                 path: '/payroll',
                 children: [
-                  { path: 'upload', element: <PayrollUpload /> },
-                  { path: 'results', element: <PayrollResults /> },
+                  {
+                    path: 'upload',
+                    lazy: async () => {
+                      const { PayrollUpload } = await import(
+                        '@/modules/payroll/pages/PayrollUpload'
+                      )
+                      return { Component: PayrollUpload }
+                    },
+                  },
+                  {
+                    path: 'results',
+                    lazy: async () => {
+                      const { PayrollResults } = await import(
+                        '@/modules/payroll/pages/PayrollResults'
+                      )
+                      return { Component: PayrollResults }
+                    },
+                  },
                   { index: true, element: <Navigate to="upload" replace /> },
                 ],
               },
@@ -49,8 +48,24 @@ export const toolRoutes: RouteObject[] = [
               {
                 path: '/roster',
                 children: [
-                  { path: 'upload', element: <RosterUpload /> },
-                  { path: 'results/:rosterId', element: <RosterResults /> },
+                  {
+                    path: 'upload',
+                    lazy: async () => {
+                      const { RosterUpload } = await import(
+                        '@/modules/roster/pages/RosterUpload'
+                      )
+                      return { Component: RosterUpload }
+                    },
+                  },
+                  {
+                    path: 'results/:rosterId',
+                    lazy: async () => {
+                      const { RosterResults } = await import(
+                        '@/modules/roster/pages/RosterResults'
+                      )
+                      return { Component: RosterResults }
+                    },
+                  },
                   { index: true, element: <Navigate to="upload" replace /> },
                 ],
               },
@@ -64,9 +79,33 @@ export const toolRoutes: RouteObject[] = [
               {
                 path: '/documents',
                 children: [
-                  { path: 'templates', element: <DocumentTemplates /> },
-                  { path: 'generate', element: <GenerateDocument /> },
-                  { path: 'library', element: <DocumentLibrary /> },
+                  {
+                    path: 'templates',
+                    lazy: async () => {
+                      const { DocumentTemplates } = await import(
+                        '@/modules/documents/pages/DocumentTemplates'
+                      )
+                      return { Component: DocumentTemplates }
+                    },
+                  },
+                  {
+                    path: 'generate',
+                    lazy: async () => {
+                      const { GenerateDocument } = await import(
+                        '@/modules/documents/pages/GenerateDocument'
+                      )
+                      return { Component: GenerateDocument }
+                    },
+                  },
+                  {
+                    path: 'library',
+                    lazy: async () => {
+                      const { DocumentLibrary } = await import(
+                        '@/modules/documents/pages/DocumentLibrary'
+                      )
+                      return { Component: DocumentLibrary }
+                    },
+                  },
                   { index: true, element: <Navigate to="templates" replace /> },
                 ],
               },
@@ -79,7 +118,12 @@ export const toolRoutes: RouteObject[] = [
             children: [
               {
                 path: '/settings',
-                element: <Settings />,
+                lazy: async () => {
+                  const { Settings } = await import(
+                    '@/modules/settings/pages/Settings'
+                  )
+                  return { Component: Settings }
+                },
               },
             ],
           },

--- a/frontend/src/shared/compliance-check/utils/formatters.ts
+++ b/frontend/src/shared/compliance-check/utils/formatters.ts
@@ -82,8 +82,6 @@ export function formatFileSize(bytes: number): string {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
 }
 
-import * as XLSX from 'xlsx'
-
 /**
  * Escape a CSV field value
  * Wraps in quotes if contains comma, quote, or newline
@@ -121,10 +119,19 @@ interface ExportMetadata {
 /**
  * Export compliance results to Excel (.xlsx) and trigger download
  */
-export function exportComplianceXlsx(
+let xlsxModulePromise: Promise<typeof import('xlsx')> | null = null
+
+async function loadXlsx() {
+  if (!xlsxModulePromise) {
+    xlsxModulePromise = import('xlsx')
+  }
+  return xlsxModulePromise
+}
+
+export async function exportComplianceXlsx(
   metadata: ExportMetadata,
   categories: ExportableCategory[]
-): void {
+): Promise<void> {
   const rows = categories.flatMap(category =>
     category.issues.map(issue => ({
       Category: category.title,
@@ -138,6 +145,7 @@ export function exportComplianceXlsx(
     }))
   )
 
+  const XLSX = await loadXlsx()
   const worksheet = XLSX.utils.json_to_sheet(rows)
   const workbook = XLSX.utils.book_new()
   XLSX.utils.book_append_sheet(workbook, worksheet, 'Compliance Report')


### PR DESCRIPTION
## Summary
- convert error, public, and tool routes to lazy-loaded route components to reduce eager frontend bundle cost
- lazy-load the xlsx dependency inside compliance export instead of importing it into the initial bundle

## Testing
- build was not re-run in the clean temporary worktree because frontend dependencies were not installed there ( and  type defs were unavailable)
- code changes are limited to route-level dynamic imports and deferred xlsx loading