### PR TITLE
chore: remove legacy RDS defaults

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -102,7 +102,7 @@ Once installed, simply **Save (Ctrl+S)** any `.cs` file, and it will be formatte
 
 ### 5. Application Configuration
 
-Both `appsettings.json` and `appsettings.Development.json` are git-ignored. The repo provides `.example` templates — copy them and edit locally.
+`appsettings.Development.json` is git-ignored. The repo provides `.example` templates for local setup.
 
 **Step 1: Create `appsettings.json`** (base config, all environments)
 
@@ -113,6 +113,10 @@ cp src/FairWorkly.API/appsettings.example.json src/FairWorkly.API/appsettings.js
 What to change:
 - `ConnectionStrings:DefaultConnection` — your Postgres host, port, credentials
 - `JwtSettings:Secret` — must be non-empty; 32+ chars recommended
+
+What the tracked base config assumes:
+- `appsettings.json` now defaults to a local/container Postgres connection, not the legacy RDS instance
+- UAT/prod should override `ConnectionStrings__DefaultConnection` and secrets via environment variables during deploy
 
 What you can leave as-is for local dev:
 - `AiSettings:BaseUrl` — defaults to `localhost:8000` (Python agent-service)

--- a/backend/src/FairWorkly.API/appsettings.json
+++ b/backend/src/FairWorkly.API/appsettings.json
@@ -9,7 +9,7 @@
   "AllowedHosts": "*",
 
   "ConnectionStrings": {
-    "DefaultConnection": "Host=fairworly-database-1.c3i2igo4c9wg.ap-southeast-2.rds.amazonaws.com;Port=5432;Database=postgres;Username=postgres;Password=REPLACE_ME;SSL Mode=Require;Trust Server Certificate=true"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=FairWorklyDb;Username=postgres;Password=REPLACE_ME"
   },
 
   "AiSettings": {
@@ -28,7 +28,7 @@
   },
 
   "JwtSettings": {
-    "Secret": "dev-secret-change-before-production-1234567890",
+    "Secret": "REPLACE_IN_ENVIRONMENT",
     "Issuer": "FairWorkly.Auth",
     "Audience": "FairWorkly.Web",
     "ExpiryMinutes": 15,


### PR DESCRIPTION
## Summary
- replace the tracked backend default connection string with a local/container Postgres default
- replace the tracked JWT secret placeholder so production environments must provide it explicitly
- update backend config docs to reflect that UAT/prod should override connection strings and secrets via environment variables

## Why
We have already moved runtime data off the legacy RDS instance. Keeping an RDS host in the tracked default config makes it too easy for future deploys or local setup to drift back toward the retired database path.

## Validation
- checked that backend config/docs no longer reference the old RDS host
- ran `git diff --check`

## Follow-up
After this is merged, DevOps can safely finish the RDS retirement process once runtime environments are confirmed to be using the EC2/container Postgres instance and a final snapshot has been taken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance to reflect local PostgreSQL setup for development environments.
  * Clarified that environment variables should be used for production secrets and connection strings during deployment.

* **Chores**
  * Updated default configuration to use local database connection instead of cloud-hosted instance.
  * Modified credential handling to use environment variable placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->